### PR TITLE
Add initial HACS integration scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # kippy-homeassistant
-A Home Assistant HACS integration for Kippy pet trackers
+
+A Home Assistant HACS integration for Kippy pet trackers.
+
+## Installation
+
+1. Copy `custom_components/kippy` to your Home Assistant `custom_components` directory or install via HACS.
+2. Restart Home Assistant.
+3. Configure the integration via the Home Assistant UI.
+
+This repository is a work in progress and provides only a basic skeleton for future development.

--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -1,0 +1,21 @@
+"""The Kippy integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from .const import DOMAIN
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Kippy from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    session = aiohttp_client.async_get_clientsession(hass)
+    # TODO: Initialize API client using session
+    hass.data[DOMAIN][entry.entry_id] = {"session": session}
+    return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Kippy config entry."""
+    hass.data[DOMAIN].pop(entry.entry_id)
+    return True

--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -1,0 +1,27 @@
+"""Config flow for the Kippy integration."""
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+class KippyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Kippy."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is not None:
+            # TODO: Validate user input with API
+            return self.async_create_entry(title=user_input["username"], data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("username"): str,
+                vol.Required("password"): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -1,0 +1,2 @@
+"""Constants for the Kippy integration."""
+DOMAIN = "kippy"

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -1,0 +1,26 @@
+"""Coordinator for Kippy data updates."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+class KippyDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from the Kippy API."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            hass.logger,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=1),
+        )
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint."""
+        # TODO: Implement API call
+        return {}

--- a/custom_components/kippy/manifest.json
+++ b/custom_components/kippy/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "kippy",
+  "name": "Kippy",
+  "version": "0.1.0",
+  "documentation": "https://github.com/example/kippy-homeassistant",
+  "requirements": [],
+  "codeowners": ["@example"],
+  "config_flow": true,
+  "iot_class": "cloud_polling",
+  "integration_type": "hub"
+}

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -1,0 +1,29 @@
+"""Sensor platform for Kippy."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+from .coordinator import KippyDataUpdateCoordinator
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigType, async_add_entities) -> None:
+    """Set up Kippy sensors."""
+    coordinator = KippyDataUpdateCoordinator(hass)
+    await coordinator.async_config_entry_first_refresh()
+    async_add_entities([KippyExampleSensor(coordinator)])
+
+class KippyExampleSensor(SensorEntity):
+    """Representation of an example Kippy sensor."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        self.coordinator = coordinator
+        self._attr_name = "Kippy Example"
+        self._attr_unique_id = "kippy_example"
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data.get("example")

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -1,0 +1,13 @@
+{
+  "title": "Kippy",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -1,0 +1,15 @@
+{
+  "title": "Kippy",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Kippy",
+        "description": "Connect to your Kippy account",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kippy",
+  "domains": ["kippy"],
+  "render_readme": true
+}


### PR DESCRIPTION
## Summary
- scaffold Kippy custom component for Home Assistant
- add HACS metadata and basic documentation

## Testing
- `python -m py_compile $(git ls-files '*.py') $(find custom_components -name '*.py')`
- `python -m hassfest` *(fails: No module named hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_68b0da619108832689c058e3362af4ed