### PR TITLE
Use email instead of username for Kippy login

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -2,17 +2,20 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 
+from .api import KippyApi
 from .const import DOMAIN
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kippy from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     session = aiohttp_client.async_get_clientsession(hass)
-    # TODO: Initialize API client using session
-    hass.data[DOMAIN][entry.entry_id] = {"session": session}
+    api = KippyApi(session)
+    await api.login(entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD])
+    hass.data[DOMAIN][entry.entry_id] = {"api": api}
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -1,0 +1,93 @@
+"""Simple API client for Kippy."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from aiohttp import ClientSession
+
+DEFAULT_LOGIN_URL = "https://prod.kippyapi.eu/v2/login.php"
+
+class KippyApi:
+    """Minimal Kippy API wrapper handling authentication."""
+
+    def __init__(self, session: ClientSession, login_url: str = DEFAULT_LOGIN_URL) -> None:
+        """Initialize the API client."""
+        self._session = session
+        self._login_url = login_url
+        self._auth: Optional[Dict[str, Any]] = None
+        self._token: Optional[str] = None
+        self._token_expiry: Optional[datetime] = None
+        self._email: Optional[str] = None
+        self._password: Optional[str] = None
+
+    @property
+    def token(self) -> Optional[str]:
+        """Return the cached session token if available."""
+        return self._token
+
+    async def login(self, email: str, password: str, force: bool = False) -> Dict[str, Any]:
+        """Login to the Kippy API and cache the session.
+
+        If a non-expired login session is already cached, it will be returned
+        without performing a new network request unless ``force`` is True.
+        """
+        now = datetime.utcnow()
+        if (
+            not force
+            and self._auth is not None
+            and (self._token_expiry is None or now < self._token_expiry)
+        ):
+            return self._auth
+
+        sha256_hex = hashlib.sha256(password.encode("utf-8")).hexdigest()
+        md5_hex = hashlib.md5(password.encode("utf-8")).hexdigest()
+
+        payload = {
+            "login_email": email,
+            "login_password_hash": sha256_hex,
+            "login_password_hash_md5": md5_hex,
+            "app_identity": "evo",
+            "app_identity_evo": "1",
+            "platform_device": "10",
+            "app_version": "2.9.9",
+            "timezone": 1.0,
+            "phone_country_code": "1",
+            "token_device": None,
+            "device_name": "homeassistant",
+        }
+
+        headers = {
+            "Content-Type": "text/plain; charset=utf-8",
+            "Accept": "application/json, */*;q=0.8",
+            "User-Agent": "kippy-ha/0.1 (+aiohttp)",
+        }
+
+        async with self._session.post(
+            self._login_url, data=json.dumps(payload), headers=headers
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+
+        self._auth = data
+        self._email = email
+        self._password = password
+        self._token = data.get("token") or data.get("login_token") or data.get("auth_token")
+        expires_in = data.get("token_expires_in") or data.get("expires_in")
+        expire_at = data.get("token_expires_at") or data.get("expire_at")
+        if expires_in is not None:
+            self._token_expiry = now + timedelta(seconds=int(expires_in))
+        elif expire_at is not None:
+            self._token_expiry = datetime.utcfromtimestamp(int(expire_at))
+        else:
+            self._token_expiry = None
+
+        return data
+
+    async def ensure_login(self) -> None:
+        """Ensure a valid login session is available."""
+        if self._email is None or self._password is None:
+            raise RuntimeError("No stored credentials; call login() first")
+        await self.login(self._email, self._password)

--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
 
+from .api import KippyApi
 from .const import DOMAIN
 
 class KippyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -14,14 +17,22 @@ class KippyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            # TODO: Validate user input with API
-            return self.async_create_entry(title=user_input["username"], data=user_input)
+            session = aiohttp_client.async_get_clientsession(self.hass)
+            api = KippyApi(session)
+            try:
+                await api.login(user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
+            except Exception:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(title=user_input[CONF_EMAIL], data=user_input)
 
         data_schema = vol.Schema(
             {
-                vol.Required("username"): str,
-                vol.Required("password"): str,
+                vol.Required(CONF_EMAIL): str,
+                vol.Required(CONF_PASSWORD): str,
             }
         )
-        return self.async_show_form(step_id="user", data_schema=data_schema)
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -6,13 +6,15 @@ from datetime import timedelta
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .api import KippyApi
 from .const import DOMAIN
 
 class KippyDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the Kippy API."""
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, api: KippyApi) -> None:
         """Initialize the coordinator."""
+        self.api = api
         super().__init__(
             hass,
             hass.logger,
@@ -22,5 +24,6 @@ class KippyDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
-        # TODO: Implement API call
+        await self.api.ensure_login()
+        # TODO: Implement API call to fetch device data using self.api
         return {}

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -2,15 +2,16 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 from .coordinator import KippyDataUpdateCoordinator
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigType, async_add_entities) -> None:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     """Set up Kippy sensors."""
-    coordinator = KippyDataUpdateCoordinator(hass)
+    api = hass.data[DOMAIN][entry.entry_id]["api"]
+    coordinator = KippyDataUpdateCoordinator(hass, api)
     await coordinator.async_config_entry_first_refresh()
     async_add_entities([KippyExampleSensor(coordinator)])
 

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "user": {
         "data": {
-          "username": "Username",
+          "email": "Email",
           "password": "Password"
         }
       }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -6,7 +6,7 @@
         "title": "Kippy",
         "description": "Connect to your Kippy account",
         "data": {
-          "username": "Username",
+          "email": "Email",
           "password": "Password"
         }
       }


### PR DESCRIPTION
## Summary
- adjust Kippy config flow and setup to authenticate with email rather than username
- update translations to label the field as "Email"

## Testing
- `python -m py_compile custom_components/kippy/api.py custom_components/kippy/__init__.py custom_components/kippy/config_flow.py custom_components/kippy/coordinator.py custom_components/kippy/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b309863adc8326aca556903a75b45c