### PR TITLE
Remove username references from Kippy integration

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -14,7 +14,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     session = aiohttp_client.async_get_clientsession(hass)
     api = KippyApi(session)
-    await api.login(entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD])
+    email = entry.data.get(CONF_EMAIL)
+    password = entry.data.get(CONF_PASSWORD)
+    if not email or not password:
+        return False
+    await api.login(email, password)
     hass.data[DOMAIN][entry.entry_id] = {"api": api}
     return True
 


### PR DESCRIPTION
## Summary
- drop legacy username fallback; configuration now relies solely on email credentials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35827851c832694911ff139348cc2