### PR TITLE
Improve Kippy config error message

### DIFF
--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -1,6 +1,9 @@
 {
   "title": "Kippy",
   "config": {
+    "error": {
+      "cannot_connect": "Failed to connect"
+    },
     "step": {
       "user": {
         "data": {

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -1,6 +1,9 @@
 {
   "title": "Kippy",
   "config": {
+    "error": {
+      "cannot_connect": "Failed to connect"
+    },
     "step": {
       "user": {
         "title": "Kippy",


### PR DESCRIPTION
## Summary
- add missing translation for `cannot_connect`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b367cdba488326926ca298a3659d95