### PR TITLE
Handle auth and connection errors separately

### DIFF
--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -2,7 +2,8 @@
   "title": "Kippy",
   "config": {
     "error": {
-      "cannot_connect": "Failed to connect"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication"
     },
     "step": {
       "user": {

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -2,7 +2,8 @@
   "title": "Kippy",
   "config": {
     "error": {
-      "cannot_connect": "Failed to connect"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication"
     },
     "step": {
       "user": {


### PR DESCRIPTION
## Summary
- Distinguish invalid credentials from connection problems during login
- Provide error strings and translations for `invalid_auth`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4164220008326b9fdeee7c24636fa