### PR TITLE
Handle login failure based on return code

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -97,6 +97,21 @@ class KippyApi:
                     )
                     raise
                 data = json.loads(resp_text)
+                return_code = data.get("return")
+                if return_code not in (0, "0"):
+                    _LOGGER.debug(
+                        "Login failed: return=%s request=%s response=%s",
+                        return_code,
+                        payload,
+                        resp_text,
+                    )
+                    raise ClientResponseError(
+                        resp.request_info,
+                        resp.history,
+                        status=401,
+                        message=resp_text,
+                        headers=resp.headers,
+                    )
         except ClientError as err:
             _LOGGER.debug(
                 "Error communicating with Kippy API: request=%s error=%s",


### PR DESCRIPTION
## Summary
- verify login responses by checking the `return` field and raise `ClientResponseError` when non-zero

## Testing
- `python -m py_compile custom_components/kippy/api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4279fc8908326960261b18faa976b