### PR TITLE
Handle pet list structure in coordinator and sensor

### DIFF
--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -25,4 +25,4 @@ class KippyDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
         await self.api.ensure_login()
-        return await self.api.get_pet_kippy_list()
+        return {"pets": await self.api.get_pet_kippy_list()}

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -27,4 +27,4 @@ class KippyExampleSensor(SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        return self.coordinator.data.get("example")
+        return len(self.coordinator.data.get("pets", []))


### PR DESCRIPTION
## Summary
- keep coordinator data as a mapping with `pets`
- report pet count from example sensor

## Testing
- `python -m py_compile custom_components/kippy/api.py custom_components/kippy/coordinator.py custom_components/kippy/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b43a291e0083268115a649c429d77e