### PR TITLE
Add Kippy pet device trackers

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 
 from .api import KippyApi
-from .const import DOMAIN
+from .const import DOMAIN, PLATFORMS
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kippy from a config entry."""
@@ -20,9 +20,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
     await api.login(email, password)
     hass.data[DOMAIN][entry.entry_id] = {"api": api}
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Kippy config entry."""
+    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     hass.data[DOMAIN].pop(entry.entry_id)
     return True

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -1,2 +1,6 @@
 """Constants for the Kippy integration."""
 DOMAIN = "kippy"
+
+# The integration exposes only device tracker entities. The list is kept
+# separate so ``async_forward_entry_setups`` can be used in ``__init__``.
+PLATFORMS: list[str] = ["device_tracker"]

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -1,8 +1,6 @@
 """Coordinator for Kippy data updates."""
 from __future__ import annotations
 
-from datetime import timedelta
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -19,10 +17,12 @@ class KippyDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             hass.logger,
             name=DOMAIN,
-            update_interval=timedelta(minutes=1),
+            # Fetching the pet list does not need to happen on a schedule.
+            # The coordinator will only update when explicitly requested.
+            update_interval=None,
         )
 
     async def _async_update_data(self):
-        """Fetch data from API endpoint."""
-        await self.api.ensure_login()
+        """Fetch data from the API endpoint."""
+        # ``get_pet_kippy_list`` internally ensures a valid login session.
         return {"pets": await self.api.get_pet_kippy_list()}

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -1,0 +1,75 @@
+"""Device tracker platform for Kippy pets."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.device_tracker import TrackerEntity, SourceType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KippyDataUpdateCoordinator
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    """Set up Kippy device trackers."""
+    api = hass.data[DOMAIN][entry.entry_id]["api"]
+    coordinator = KippyDataUpdateCoordinator(hass, api)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
+
+    entities = [KippyPetTracker(coordinator, pet) for pet in coordinator.data.get("pets", [])]
+    async_add_entities(entities)
+
+
+class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEntity):
+    """Representation of a Kippy tracked pet."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        """Initialize the tracker entity."""
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._attr_name = pet.get("petName")
+        self._attr_unique_id = pet["petID"]
+        self._pet_data = pet
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the attributes provided by the API."""
+        return self._pet_data
+
+    @property
+    def source_type(self) -> SourceType:
+        """GPS will be provided in a separate update flow later."""
+        return SourceType.GPS
+
+    @property
+    def latitude(self) -> float | None:
+        """Return latitude if available."""
+        return None
+
+    @property
+    def longitude(self) -> float | None:
+        """Return longitude if available."""
+        return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this pet."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=self._attr_name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        """Update internal data from the coordinator."""
+        for pet in self.coordinator.data.get("pets", []):
+            if pet.get("petID") == self._pet_id:
+                self._pet_data = pet
+                break
+        super()._handle_coordinator_update()


### PR DESCRIPTION
## Summary
- create device tracker entity for each pet with all API attributes
- avoid polling GetPetKippyList every minute; refresh only on demand

## Testing
- `python -m py_compile custom_components/kippy/const.py custom_components/kippy/coordinator.py custom_components/kippy/__init__.py custom_components/kippy/device_tracker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b448f60d748326823c3bf63b2caca2