### PR TITLE
Fix coordinator logger usage

### DIFF
--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -1,11 +1,15 @@
 """Coordinator for Kippy data updates."""
 from __future__ import annotations
 
+import logging
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .api import KippyApi
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 class KippyDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the Kippy API."""
@@ -15,7 +19,7 @@ class KippyDataUpdateCoordinator(DataUpdateCoordinator):
         self.api = api
         super().__init__(
             hass,
-            hass.logger,
+            _LOGGER,
             name=DOMAIN,
             # Fetching the pet list does not need to happen on a schedule.
             # The coordinator will only update when explicitly requested.


### PR DESCRIPTION
## Summary
- Use standard logging for KippyDataUpdateCoordinator instead of hass.logger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b44f22bdac8326b5a8efc4a69bc843