### PR TITLE
Initialize Kippy coordinator before forwarding platforms

### DIFF
--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -15,12 +15,12 @@ from .coordinator import KippyDataUpdateCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     """Set up Kippy device trackers."""
-    api = hass.data[DOMAIN][entry.entry_id]["api"]
-    coordinator = KippyDataUpdateCoordinator(hass, api)
-    await coordinator.async_config_entry_first_refresh()
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-    entities = [KippyPetTracker(coordinator, pet) for pet in coordinator.data.get("pets", [])]
+    entities = [
+        KippyPetTracker(coordinator, pet)
+        for pet in coordinator.data.get("pets", [])
+    ]
     async_add_entities(entities)
 
 

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -10,9 +10,7 @@ from .coordinator import KippyDataUpdateCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     """Set up Kippy sensors."""
-    api = hass.data[DOMAIN][entry.entry_id]["api"]
-    coordinator = KippyDataUpdateCoordinator(hass, api)
-    await coordinator.async_config_entry_first_refresh()
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     async_add_entities([KippyExampleSensor(coordinator)])
 
 class KippyExampleSensor(SensorEntity):


### PR DESCRIPTION
## Summary
- Initialize Kippy DataUpdateCoordinator during integration setup and raise `ConfigEntryNotReady` if initial refresh fails
- Share the initialized coordinator with device tracker and sensor platforms

## Testing
- `python -m pytest`
- `python -m py_compile custom_components/kippy/__init__.py custom_components/kippy/device_tracker.py custom_components/kippy/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b455d26bec8326b9d01607562d4fcf