### PR TITLE
Prefix device names with Kippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Home Assistant HACS integration for Kippy pet trackers.
 
+Device trackers created by this integration are prefixed with `Kippy` and your pet's name (for example, `Kippy Tilly`).
+
 ## Installation
 
 1. Copy `custom_components/kippy` to your Home Assistant `custom_components` directory or install via HACS.

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -31,7 +31,8 @@ class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEnti
         """Initialize the tracker entity."""
         super().__init__(coordinator)
         self._pet_id = pet["petID"]
-        self._attr_name = pet.get("petName")
+        pet_name = pet.get("petName")
+        self._attr_name = f"Kippy {pet_name}" if pet_name else "Kippy"
         self._attr_unique_id = pet["petID"]
         self._pet_data = pet
 
@@ -71,5 +72,7 @@ class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEnti
         for pet in self.coordinator.data.get("pets", []):
             if pet.get("petID") == self._pet_id:
                 self._pet_data = pet
+                pet_name = pet.get("petName")
+                self._attr_name = f"Kippy {pet_name}" if pet_name else "Kippy"
                 break
         super()._handle_coordinator_update()


### PR DESCRIPTION
## Summary
- prefix device tracker entity names with "Kippy "
- document Kippy device naming convention in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47bfab46c8326beaa56f7b6d45150