### PR TITLE
Expose additional Kippy pet attributes

### DIFF
--- a/custom_components/kippy/binary_sensor.py
+++ b/custom_components/kippy/binary_sensor.py
@@ -1,0 +1,62 @@
+"""Binary sensors for Kippy pets."""
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KippyDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Kippy binary sensors."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[BinarySensorEntity] = []
+    for pet in coordinator.data.get("pets", []):
+        entities.append(KippyFirmwareUpgradeBinarySensor(coordinator, pet))
+    async_add_entities(entities)
+
+
+class KippyFirmwareUpgradeBinarySensor(
+    CoordinatorEntity[KippyDataUpdateCoordinator], BinarySensorEntity
+):
+    """Binary sensor indicating firmware upgrade needed."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        pet_name = pet.get("petName")
+        self._attr_name = (
+            f"{pet_name} Firmware Upgrade" if pet_name else "Firmware Upgrade"
+        )
+        self._attr_unique_id = f"{self._pet_id}_firmware_upgrade"
+        self._pet_data = pet
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self._pet_data.get("firmware_need_upgrade"))
+
+    def _handle_coordinator_update(self) -> None:
+        for pet in self.coordinator.data.get("pets", []):
+            if pet.get("petID") == self._pet_id:
+                self._pet_data = pet
+                break
+        super()._handle_coordinator_update()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        pet_name = self._pet_data.get("petName")
+        name = f"Kippy {pet_name}" if pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -1,6 +1,12 @@
 """Constants for the Kippy integration."""
 DOMAIN = "kippy"
 
-# The integration exposes only device tracker entities. The list is kept
+# The integration exposes multiple entity types. The list is kept
 # separate so ``async_forward_entry_setups`` can be used in ``__init__``.
-PLATFORMS: list[str] = ["device_tracker"]
+PLATFORMS: list[str] = [
+    "device_tracker",
+    "sensor",
+    "number",
+    "switch",
+    "binary_sensor",
+]

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -39,7 +39,24 @@ class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEnti
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes provided by the API."""
-        return self._pet_data
+        attrs = dict(self._pet_data)
+        expired_days = attrs.get("expired_days")
+        if isinstance(expired_days, (int, str)):
+            try:
+                expired_days = int(expired_days)
+                attrs["expired_days"] = (
+                    abs(expired_days) if expired_days < 0 else "Expired"
+                )
+            except ValueError:
+                pass
+
+        kind = attrs.get("petKind")
+        if kind == 4:
+            attrs["petKind"] = "dog"
+        elif kind == 3:
+            attrs["petKind"] = "cat"
+
+        return attrs
 
     @property
     def source_type(self) -> SourceType:

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -1,0 +1,68 @@
+"""Number entities for Kippy pets."""
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KippyDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Kippy number entities."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[NumberEntity] = []
+    for pet in coordinator.data.get("pets", []):
+        entities.append(KippyUpdateFrequencyNumber(coordinator, pet))
+    async_add_entities(entities)
+
+
+class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], NumberEntity):
+    """Number entity for update frequency."""
+
+    _attr_native_min_value = 1
+    _attr_native_step = 1
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        pet_name = pet.get("petName")
+        self._attr_name = (
+            f"{pet_name} Update Frequency" if pet_name else "Update Frequency"
+        )
+        self._attr_unique_id = f"{self._pet_id}_update_frequency"
+        self._pet_data = pet
+
+    @property
+    def native_value(self) -> float | None:
+        value = self._pet_data.get("updateFrequency")
+        return float(value) if value is not None else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        self._pet_data["updateFrequency"] = int(value)
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        for pet in self.coordinator.data.get("pets", []):
+            if pet.get("petID") == self._pet_id:
+                self._pet_data = pet
+                break
+        super()._handle_coordinator_update()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        pet_name = self._pet_data.get("petName")
+        name = f"Kippy {pet_name}" if pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -1,28 +1,96 @@
-"""Sensor platform for Kippy."""
+"""Sensor platform for Kippy pets."""
 from __future__ import annotations
+
+from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import KippyDataUpdateCoordinator
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
     """Set up Kippy sensors."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    async_add_entities([KippyExampleSensor(coordinator)])
+    entities: list[SensorEntity] = []
+    for pet in coordinator.data.get("pets", []):
+        entities.append(KippyExpiredDaysSensor(coordinator, pet))
+        entities.append(KippyPetKindSensor(coordinator, pet))
+    async_add_entities(entities)
 
-class KippyExampleSensor(SensorEntity):
-    """Representation of an example Kippy sensor."""
 
-    def __init__(self, coordinator: KippyDataUpdateCoordinator) -> None:
-        """Initialize the sensor."""
-        self.coordinator = coordinator
-        self._attr_name = "Kippy Example"
-        self._attr_unique_id = "kippy_example"
+class _KippyBaseEntity(CoordinatorEntity[KippyDataUpdateCoordinator]):
+    """Base entity for Kippy sensors."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_data = pet
+
+    def _handle_coordinator_update(self) -> None:
+        for pet in self.coordinator.data.get("pets", []):
+            if pet.get("petID") == self._pet_id:
+                self._pet_data = pet
+                break
+        super()._handle_coordinator_update()
 
     @property
-    def native_value(self):
-        """Return the state of the sensor."""
-        return len(self.coordinator.data.get("pets", []))
+    def device_info(self) -> DeviceInfo:
+        pet_name = self._pet_data.get("petName")
+        name = f"Kippy {pet_name}" if pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+
+
+class KippyExpiredDaysSensor(_KippyBaseEntity, SensorEntity):
+    """Sensor for remaining service days."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator, pet)
+        pet_name = pet.get("petName")
+        self._attr_name = (
+            f"{pet_name} Days Until Expiry" if pet_name else "Days Until Expiry"
+        )
+        self._attr_unique_id = f"{self._pet_id}_expired_days"
+
+    @property
+    def native_value(self) -> Any:
+        days = self._pet_data.get("expired_days")
+        if days is None:
+            return None
+        try:
+            days = int(days)
+        except (TypeError, ValueError):
+            return None
+        return abs(days) if days < 0 else "Expired"
+
+
+class KippyPetKindSensor(_KippyBaseEntity, SensorEntity):
+    """Sensor for pet type."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator, pet)
+        pet_name = pet.get("petName")
+        self._attr_name = f"{pet_name} Kind" if pet_name else "Pet Kind"
+        self._attr_unique_id = f"{self._pet_id}_kind"
+
+    @property
+    def native_value(self) -> str | None:
+        kind = self._pet_data.get("petKind")
+        if kind == 4:
+            return "dog"
+        if kind == 3:
+            return "cat"
+        return None
+

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -1,0 +1,72 @@
+"""Switch entities for Kippy pets."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KippyDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Kippy switch entities."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[SwitchEntity] = []
+    for pet in coordinator.data.get("pets", []):
+        entities.append(KippyEnergySavingSwitch(coordinator, pet))
+    async_add_entities(entities)
+
+
+class KippyEnergySavingSwitch(
+    CoordinatorEntity[KippyDataUpdateCoordinator], SwitchEntity
+):
+    """Switch for energy saving mode."""
+
+    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        pet_name = pet.get("petName")
+        self._attr_name = (
+            f"{pet_name} Energy Saving" if pet_name else "Energy Saving"
+        )
+        self._attr_unique_id = f"{self._pet_id}_energy_saving"
+        self._pet_data = pet
+
+    @property
+    def is_on(self) -> bool:
+        return bool(int(self._pet_data.get("energySavingMode", 0)))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        self._pet_data["energySavingMode"] = 1
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        self._pet_data["energySavingMode"] = 0
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        for pet in self.coordinator.data.get("pets", []):
+            if pet.get("petID") == self._pet_id:
+                self._pet_data = pet
+                break
+        super()._handle_coordinator_update()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        pet_name = self._pet_data.get("petName")
+        name = f"Kippy {pet_name}" if pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+


### PR DESCRIPTION
## Summary
- expose more Kippy platforms for sensors, numbers, switches and binary sensors
- add entities for update frequency, energy saving mode, firmware upgrade, pet kind and expiry days
- normalize API attributes for pet kind and subscription expiry

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b480917cf88326837a91032fae736c