### PR TITLE
Refine Kippy entity names and limits

### DIFF
--- a/custom_components/kippy/binary_sensor.py
+++ b/custom_components/kippy/binary_sensor.py
@@ -18,24 +18,25 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     entities: list[BinarySensorEntity] = []
     for pet in coordinator.data.get("pets", []):
-        entities.append(KippyFirmwareUpgradeBinarySensor(coordinator, pet))
+        entities.append(KippyFirmwareUpgradeAvailableBinarySensor(coordinator, pet))
     async_add_entities(entities)
 
 
-class KippyFirmwareUpgradeBinarySensor(
+class KippyFirmwareUpgradeAvailableBinarySensor(
     CoordinatorEntity[KippyDataUpdateCoordinator], BinarySensorEntity
 ):
-    """Binary sensor indicating firmware upgrade needed."""
+    """Binary sensor indicating firmware upgrade availability."""
 
     def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
         super().__init__(coordinator)
         self._pet_id = pet["petID"]
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} Firmware Upgrade" if pet_name else "Firmware Upgrade"
+            f"{pet_name} Firmware Upgrade available" if pet_name else "Firmware Upgrade available"
         )
         self._attr_unique_id = f"{self._pet_id}_firmware_upgrade"
         self._pet_data = pet
+        self._attr_translation_key = "firmware_upgrade_available"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -50,11 +50,11 @@ class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEnti
             except ValueError:
                 pass
 
-        kind = attrs.get("petKind")
-        if kind == 4:
-            attrs["petKind"] = "dog"
-        elif kind == 3:
-            attrs["petKind"] = "cat"
+        pet_kind = attrs.pop("petKind", None)
+        if pet_kind == 4:
+            attrs["petType"] = "dog"
+        elif pet_kind == 3:
+            attrs["petType"] = "cat"
 
         return attrs
 

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -26,6 +26,7 @@ class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], 
     """Number entity for update frequency."""
 
     _attr_native_min_value = 1
+    _attr_native_max_value = 24
     _attr_native_step = 1
 
     def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
     for pet in coordinator.data.get("pets", []):
         entities.append(KippyExpiredDaysSensor(coordinator, pet))
-        entities.append(KippyPetKindSensor(coordinator, pet))
+        entities.append(KippyPetTypeSensor(coordinator, pet))
     async_add_entities(entities)
 
 
@@ -76,14 +76,14 @@ class KippyExpiredDaysSensor(_KippyBaseEntity, SensorEntity):
         return abs(days) if days < 0 else "Expired"
 
 
-class KippyPetKindSensor(_KippyBaseEntity, SensorEntity):
+class KippyPetTypeSensor(_KippyBaseEntity, SensorEntity):
     """Sensor for pet type."""
 
     def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
         super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
-        self._attr_name = f"{pet_name} Kind" if pet_name else "Pet Kind"
-        self._attr_unique_id = f"{self._pet_id}_kind"
+        self._attr_name = f"{pet_name} Type" if pet_name else "Pet Type"
+        self._attr_unique_id = f"{self._pet_id}_type"
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -13,5 +13,16 @@
         }
       }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "firmware_upgrade_available": {
+        "name": "Firmware Upgrade available",
+        "state": {
+          "on": "Yes",
+          "off": "No"
+        }
+      }
+    }
   }
 }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -15,5 +15,16 @@
         }
       }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "firmware_upgrade_available": {
+        "name": "Firmware Upgrade available",
+        "state": {
+          "on": "Yes",
+          "off": "No"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- limit update frequency selection to once per day
- rename firmware upgrade sensor and report Yes/No status
- show pet type instead of kind

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b483adea3c8326a8ff1f54cd401872