### PR TITLE
Fix live tracking status comparison and update rescheduling

### DIFF
--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -61,20 +61,40 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch location data and adjust the refresh interval."""
         data = await self.api.kippymap_action(self.kippy_id)
         operating_status = data.get("operating_status")
+        try:
+            operating_status = int(operating_status)
+        except (TypeError, ValueError):
+            operating_status = None
         if operating_status == 1:
-            self.update_interval = timedelta(seconds=self.live_refresh)
+            self.async_set_update_interval(timedelta(seconds=self.live_refresh))
         else:
-            self.update_interval = timedelta(seconds=self.idle_refresh)
+            self.async_set_update_interval(timedelta(seconds=self.idle_refresh))
         return data
 
-    def set_idle_refresh(self, value: int) -> None:
+    async def async_set_idle_refresh(self, value: int) -> None:
         """Update idle refresh value and interval when idle."""
         self.idle_refresh = value
-        if self.data and self.data.get("operating_status") != 1:
-            self.update_interval = timedelta(seconds=self.idle_refresh)
+        if self.data:
+            operating_status = self.data.get("operating_status")
+            try:
+                operating_status = int(operating_status)
+            except (TypeError, ValueError):
+                operating_status = None
+            if operating_status != 1:
+                self.async_set_update_interval(
+                    timedelta(seconds=self.idle_refresh)
+                )
 
-    def set_live_refresh(self, value: int) -> None:
+    async def async_set_live_refresh(self, value: int) -> None:
         """Update live refresh value and interval when live."""
         self.live_refresh = value
-        if self.data and self.data.get("operating_status") == 1:
-            self.update_interval = timedelta(seconds=self.live_refresh)
+        if self.data:
+            operating_status = self.data.get("operating_status")
+            try:
+                operating_status = int(operating_status)
+            except (TypeError, ValueError):
+                operating_status = None
+            if operating_status == 1:
+                self.async_set_update_interval(
+                    timedelta(seconds=self.live_refresh)
+                )

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -98,7 +98,7 @@ class KippyIdleRefreshNumber(
         return float(self.coordinator.idle_refresh)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.set_idle_refresh(int(value))
+        await self.coordinator.async_set_idle_refresh(int(value))
         self.async_write_ha_state()
 
     @property
@@ -138,7 +138,7 @@ class KippyLiveRefreshNumber(
         return float(self.coordinator.live_refresh)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.set_live_refresh(int(value))
+        await self.coordinator.async_set_live_refresh(int(value))
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## Summary
- stop awaiting `async_set_update_interval` in map update loop and refresh setters
- update number entities to use async refresh setters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log ; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4a6aeca188326999c535522ecd409