### PR TITLE
Fix blocking SSL context creation

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -15,7 +15,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kippy from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     session = aiohttp_client.async_get_clientsession(hass)
-    api = KippyApi(session)
+    api = await KippyApi.async_create(session)
     email = entry.data.get(CONF_EMAIL)
     password = entry.data.get(CONF_PASSWORD)
     if not email or not password:

--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -25,7 +25,7 @@ class KippyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             session = aiohttp_client.async_get_clientsession(self.hass)
-            api = KippyApi(session)
+            api = await KippyApi.async_create(session)
             try:
                 await api.login(user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
             except ClientResponseError as err:


### PR DESCRIPTION
## Summary
- avoid event-loop blocking by creating SSL context in executor
- update setup and config flow to use async factory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4adee111c8326be7b813dcabe8f17