### PR TITLE
feat: add option to ignore LBS location updates

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -11,13 +11,15 @@ from typing import Any, Dict, Optional
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
 
+from .const import LOCALIZATION_TECHNOLOGY_LBS
+
 DEFAULT_HOST = "https://prod.kippyapi.eu"
 LOGIN_PATH = "/v2/login.php"
 GET_PETS_PATH = "/v2/GetPetKippyList.php"
 KIPPYMAP_ACTION_PATH = "/v2/kippymap_action.php"
 
 LOCALIZATION_TECHNOLOGY_MAP: dict[str, str] = {
-    "1": "LBS (Low accuracy)",
+    "1": LOCALIZATION_TECHNOLOGY_LBS,
     "2": "GPS",
     "3": "Wifi",
 }

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -17,6 +17,9 @@ OPERATING_STATUS_IDLE = 1
 OPERATING_STATUS_LIVE = 5
 OPERATING_STATUS_POWER_SAVING = 18
 
+# Name used by the API for low accuracy location updates
+LOCALIZATION_TECHNOLOGY_LBS = "LBS (Low accuracy)"
+
 # Mapping of ``petKind`` codes returned by the API to a human readable type.
 PET_KIND_TO_TYPE: dict[str, str] = {
     "4": "Dog",

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -38,6 +38,14 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "ignore_lbs_updates": {
+        "name": "Ignore LBS (Low accuracy) updates",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        },
+        "help": "Ignore LBS (Location-based service) location updates which can cause the Kippy device to jump very far on a map with very low accuracy"
       }
     },
     "button": {

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -7,6 +7,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 
 from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -27,7 +28,9 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = []
     for pet in coordinator.data.get("pets", []):
         entities.append(KippyEnergySavingSwitch(coordinator, pet))
-        entities.append(KippyLiveTrackingSwitch(map_coordinators[pet["petID"]], pet))
+        map_coord = map_coordinators[pet["petID"]]
+        entities.append(KippyLiveTrackingSwitch(map_coord, pet))
+        entities.append(KippyIgnoreLBSSwitch(map_coord, pet))
     async_add_entities(entities)
 
 
@@ -109,6 +112,45 @@ class KippyLiveTrackingSwitch(
             self.coordinator.kippy_id, app_action=1
         )
         self.coordinator.async_set_updated_data(data)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
+        return build_device_info(self._pet_id, self._pet_data, name)
+
+
+class KippyIgnoreLBSSwitch(
+    CoordinatorEntity[KippyMapDataUpdateCoordinator], SwitchEntity
+):
+    """Switch to ignore low accuracy LBS location updates."""
+
+    def __init__(
+        self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
+    ) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_name = pet.get("petName")
+        self._pet_data = pet
+        self._attr_name = (
+            f"{self._pet_name} Ignore LBS (Low accuracy) updates"
+            if self._pet_name
+            else "Ignore LBS (Low accuracy) updates"
+        )
+        self._attr_unique_id = f"{self._pet_id}_ignore_lbs"
+        self._attr_translation_key = "ignore_lbs_updates"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.ignore_lbs
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        self.coordinator.ignore_lbs = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        self.coordinator.ignore_lbs = False
         self.async_write_ha_state()
 
     @property

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -40,6 +40,14 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "ignore_lbs_updates": {
+        "name": "Ignore LBS (Low accuracy) updates",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        },
+        "help": "Ignore LBS (Location-based service) location updates which can cause the Kippy device to jump very far on a map with very low accuracy"
       }
     },
     "button": {


### PR DESCRIPTION
## Summary
- add new switch to ignore low accuracy LBS updates
- filter LBS localization updates from map data when enabled
- document new switch and help text in translations

## Testing
- `python -m py_compile custom_components/kippy/const.py custom_components/kippy/api.py custom_components/kippy/coordinator.py custom_components/kippy/switch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70bcaffd083268a2d5ba17995f1a0