### PR TITLE
Simplify devcontainer by using Python image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "Kippy Home Assistant HACS Dev",
-  "context": "..",
-  "dockerFile": "../Dockerfile.dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && ./script/setup",
   "postStartCommand": "./script/bootstrap",
   "containerEnv": {


### PR DESCRIPTION
## Summary
- use Python 3.13 devcontainer image instead of building from Dockerfile

## Testing
- `pre-commit run --files .devcontainer/devcontainer.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_68b83ce012288326a80bf0e257c65b67