### PR TITLE
Ensure tests load secrets from repository path

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,12 @@ import aiohttp
 import pytest
 from dotenv import load_dotenv
 
-load_dotenv(".secrets/kippy.env")
+SECRETS_FILE = Path(__file__).resolve().parents[1] / ".secrets" / "kippy.env"
+
+if SECRETS_FILE.exists():
+    load_dotenv(SECRETS_FILE)
+else:
+    pytest.skip("Missing KIPPY secrets file", allow_module_level=True)
 
 KIPPY_DIR = Path(__file__).resolve().parents[1] / "custom_components" / "kippy"
 custom_components = types.ModuleType("custom_components")
@@ -29,7 +34,7 @@ EMAIL = os.getenv("KIPPY_EMAIL")
 PASSWORD = os.getenv("KIPPY_PASSWORD")
 
 if not EMAIL or not PASSWORD:
-    pytest.skip("Missing KIPPY_EMAIL/KIPPY_PASSWORD secrets", allow_module_level=True)
+    pytest.fail("Missing KIPPY_EMAIL/KIPPY_PASSWORD secrets")
 
 
 async def _create_api() -> KippyApi:


### PR DESCRIPTION
## Summary
- Load Kippy secrets via absolute path based on test file location
- Fail fast when secrets file exists but credentials are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'custom_components.kippy'; 'custom_components' is not a package)*
- `pytest tests/test_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b99b4078cc8326a2fd2e6e0bd72072