### PR TITLE
Fix test imports for kippy custom component

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Home Assistant custom components package."""

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,19 +1,6 @@
-import importlib.util
 import json
-import sys
-import types
-from pathlib import Path
 
-KIPPY_DIR = Path(__file__).resolve().parents[1] / "custom_components" / "kippy"
-custom_components = types.ModuleType("custom_components")
-sys.modules.setdefault("custom_components", custom_components)
-spec = importlib.util.spec_from_file_location(
-    "custom_components.kippy.api", KIPPY_DIR / "api.py"
-)
-api = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(api)
-_redact = api._redact
-_redact_json = api._redact_json
+from custom_components.kippy.api import _redact, _redact_json
 
 
 def test_redact_json_handles_nested_fields():


### PR DESCRIPTION
## Summary
- simplify redaction tests by importing `_redact` helpers directly
- mark `custom_components` directory as a package

## Testing
- `pre-commit run --files tests/test_redaction.py custom_components/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3c0073c8326b116f08c9af38c99