### PR TITLE
refactor: centralize API constants

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -11,28 +11,18 @@ from typing import Any, Dict, Optional, cast
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
 
-from .const import LOCALIZATION_TECHNOLOGY_LBS
-
-DEFAULT_HOST = "https://prod.kippyapi.eu"
-LOGIN_PATH = "/v2/login.php"
-GET_PETS_PATH = "/v2/GetPetKippyList.php"
-KIPPYMAP_ACTION_PATH = "/v2/kippymap_action.php"
-GET_ACTIVITY_CATEGORIES_PATH = "/v2/vita/get_activities_cat.php"
-
-LOCALIZATION_TECHNOLOGY_MAP: dict[str, str] = {
-    "1": LOCALIZATION_TECHNOLOGY_LBS,
-    "2": "GPS",
-    "3": "Wifi",
-}
+from .const import (
+    DEFAULT_HOST,
+    GET_ACTIVITY_CATEGORIES_PATH,
+    GET_PETS_PATH,
+    KIPPYMAP_ACTION_PATH,
+    LOCALIZATION_TECHNOLOGY_MAP,
+    LOGIN_PATH,
+    LOGIN_SENSITIVE_FIELDS,
+    SENSITIVE_LOG_FIELDS,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-SENSITIVE_LOG_FIELDS = {"app_code", "app_verification_code", "petID", "auth_token"}
-LOGIN_SENSITIVE_FIELDS = {
-    "login_email",
-    "login_password_hash",
-    "login_password_hash_md5",
-}
 
 
 def _redact_tree(data: Any, sensitive: set[str]) -> Any:

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -12,16 +12,41 @@ PLATFORMS: list[str] = [
     "button",
 ]
 
+# API endpoints.
+DEFAULT_HOST = "https://prod.kippyapi.eu"
+LOGIN_PATH = "/v2/login.php"
+GET_PETS_PATH = "/v2/GetPetKippyList.php"
+KIPPYMAP_ACTION_PATH = "/v2/kippymap_action.php"
+GET_ACTIVITY_CATEGORIES_PATH = "/v2/vita/get_activities_cat.php"
+
+# Fields to redact from logs.
+SENSITIVE_LOG_FIELDS = {"app_code", "app_verification_code", "petID", "auth_token"}
+LOGIN_SENSITIVE_FIELDS = {
+    "login_email",
+    "login_password_hash",
+    "login_password_hash_md5",
+}
+
 # Mapping of operating status codes returned by the API.
 OPERATING_STATUS_IDLE = 1
 OPERATING_STATUS_LIVE = 5
 OPERATING_STATUS_POWER_SAVING = 18
 
-# Name used by the API for low accuracy location updates
+# Names used by the API for location technologies.
 LOCALIZATION_TECHNOLOGY_LBS = "LBS (Low accuracy)"
+LOCALIZATION_TECHNOLOGY_GPS = "GPS"
+LOCALIZATION_TECHNOLOGY_WIFI = "Wifi"
+
+# Mapping of localization technology codes returned by the API.
+LOCALIZATION_TECHNOLOGY_MAP: dict[str, str] = {
+    "1": LOCALIZATION_TECHNOLOGY_LBS,
+    "2": LOCALIZATION_TECHNOLOGY_GPS,
+    "3": LOCALIZATION_TECHNOLOGY_WIFI,
+}
 
 # Mapping of ``petKind`` codes returned by the API to a human readable type.
 PET_KIND_TO_TYPE: dict[str, str] = {
     "4": "Dog",
     "3": "Cat",
 }
+

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, LOCALIZATION_TECHNOLOGY_GPS
 from .coordinator import KippyDataUpdateCoordinator, KippyMapDataUpdateCoordinator
 
 
@@ -44,9 +44,9 @@ class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], 
         self._pet_id = pet["petID"]
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} GPS Automatic update frequency (hours)"
+            f"{pet_name} {LOCALIZATION_TECHNOLOGY_GPS} Automatic update frequency (hours)"
             if pet_name
-            else "GPS Automatic update frequency (hours)"
+            else f"{LOCALIZATION_TECHNOLOGY_GPS} Automatic update frequency (hours)"
         )
         self._attr_unique_id = f"{self._pet_id}_update_frequency"
         self._pet_data = pet

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -16,7 +16,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, PET_KIND_TO_TYPE
+from .const import (
+    DOMAIN,
+    LOCALIZATION_TECHNOLOGY_GPS,
+    LOCALIZATION_TECHNOLOGY_LBS,
+    PET_KIND_TO_TYPE,
+)
 from .coordinator import (
     KippyActivityCategoriesDataUpdateCoordinator,
     KippyDataUpdateCoordinator,
@@ -490,7 +495,11 @@ class KippyGpsTimeSensor(_KippyBaseMapEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
-        self._attr_name = f"{pet_name} GPS Time" if pet_name else "GPS Time"
+        self._attr_name = (
+            f"{pet_name} {LOCALIZATION_TECHNOLOGY_GPS} Time"
+            if pet_name
+            else f"{LOCALIZATION_TECHNOLOGY_GPS} Time"
+        )
         self._attr_unique_id = f"{self._pet_id}_gps_time"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -508,7 +517,11 @@ class KippyLbsTimeSensor(_KippyBaseMapEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
-        self._attr_name = f"{pet_name} LBS Time" if pet_name else "LBS Time"
+        self._attr_name = (
+            f"{pet_name} {LOCALIZATION_TECHNOLOGY_LBS} Time"
+            if pet_name
+            else f"{LOCALIZATION_TECHNOLOGY_LBS} Time"
+        )
         self._attr_unique_id = f"{self._pet_id}_lbs_time"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, OPERATING_STATUS_LIVE
+from .const import DOMAIN, LOCALIZATION_TECHNOLOGY_LBS, OPERATING_STATUS_LIVE
 from .coordinator import (
     KippyDataUpdateCoordinator,
     KippyMapDataUpdateCoordinator,
@@ -133,9 +133,9 @@ class KippyIgnoreLBSSwitch(
         self._pet_name = pet.get("petName")
         self._pet_data = pet
         self._attr_name = (
-            f"{self._pet_name} Ignore LBS (Low accuracy) updates"
+            f"{self._pet_name} Ignore {LOCALIZATION_TECHNOLOGY_LBS} updates"
             if self._pet_name
-            else "Ignore LBS (Low accuracy) updates"
+            else f"Ignore {LOCALIZATION_TECHNOLOGY_LBS} updates"
         )
         self._attr_unique_id = f"{self._pet_id}_ignore_lbs"
         self._attr_translation_key = "ignore_lbs_updates"


### PR DESCRIPTION
## Summary
- move API endpoint, redaction, and localization constants into const module
- reference new constants from API client
- reuse localization constants across number, sensor, and switch entities

## Testing
- `ruff check custom_components/kippy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa837f8e88326bd2a687e4837514a