### PR TITLE
fix: preserve pending off state for energy saving

### DIFF
--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -175,11 +175,15 @@ class KippyEnergySavingSwitch(
             return
         operating_status = self._map_coordinator.data.get("operating_status")
         if operating_status == OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]:
-            if int(self._pet_data.get("energySavingMode", 0)) != 1:
-                self._pet_data["energySavingMode"] = 1
-            if self._pet_data.get("energySavingModePending"):
-                self._pet_data["energySavingModePending"] = False
-                self.coordinator.async_set_updated_data(self.coordinator.data)
+            if not (
+                self._pet_data.get("energySavingModePending")
+                and int(self._pet_data.get("energySavingMode", 0)) == 0
+            ):
+                if int(self._pet_data.get("energySavingMode", 0)) != 1:
+                    self._pet_data["energySavingMode"] = 1
+                if self._pet_data.get("energySavingModePending"):
+                    self._pet_data["energySavingModePending"] = False
+                    self.coordinator.async_set_updated_data(self.coordinator.data)
         elif (
             self._pet_data.get("energySavingModePending")
             and int(self._pet_data.get("energySavingMode", 0)) == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -434,6 +434,9 @@ async def test_energy_saving_status_sensor_pending_and_updates() -> None:
     await switch.async_turn_off()
     assert sensor.native_value == "off_pending"
 
+    switch._handle_map_update()
+    assert sensor.native_value == "off_pending"
+
     map_coordinator.data["operating_status"] = OPERATING_STATUS_MAP[
         OPERATING_STATUS.IDLE
     ]


### PR DESCRIPTION
## Summary
- keep pending off state when map still reports energy saving
- test energy saving switch and sensor pending behavior

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `KIPPY_EMAIL='<REDACTED>' KIPPY_PASSWORD='<REDACTED>' pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bf47b9330c832682d7fd5cbfa8738f