### PR TITLE
Fix HACS validation schema

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "Kippy",
-  "domains": ["kippy"],
   "render_readme": true
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `domains` field from `hacs.json` to comply with the current HACS schema

## Testing
- python script/hassfest --integration-path custom_components/kippy
- pytest tests/test_api_fake.py tests/test_api_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68cf360bafec8326a6e275800d087598