### PR TITLE
Persist map refresh settings from number entities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: ruff check .
 
       - name: Pylint
-        run: pylint --disable=C,R custom_components/kippy
+        run: pylint custom_components/kippy
 
       - name: Pre-commit hooks
         uses: pre-commit/action@v3.0.1

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile = black
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -916,10 +916,9 @@ rules:
 
 ### Code Quality & Linting
 
+- **Required before submission**: Run `pylint custom_components/kippy` to lint the entire integration
 - **Run all linters on all files**: `pre-commit run --all-files`
 - **Run linters on staged files only**: `pre-commit run`
-- **PyLint on everything** (slow): `pylint custom_components`
-- **PyLint on specific folder**: `pylint custom_components/kippy`
 - **MyPy type checking (whole project)**: `mypy custom_components/`
 - **MyPy on specific integration**: `mypy custom_components/kippy`
 

--- a/custom_components/kippy/binary_sensor.py
+++ b/custom_components/kippy/binary_sensor.py
@@ -7,12 +7,10 @@ from typing import Any
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import KippyDataUpdateCoordinator
-from .helpers import build_device_info
+from .entity import KippyPetEntity
 
 
 async def async_setup_entry(
@@ -26,16 +24,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class KippyFirmwareUpgradeAvailableBinarySensor(
-    CoordinatorEntity[KippyDataUpdateCoordinator], BinarySensorEntity
-):
+class KippyFirmwareUpgradeAvailableBinarySensor(KippyPetEntity, BinarySensorEntity):
     """Binary sensor indicating firmware upgrade availability."""
 
     def __init__(
         self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
+        super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = (
             f"{pet_name} Firmware Upgrade available"
@@ -43,22 +38,8 @@ class KippyFirmwareUpgradeAvailableBinarySensor(
             else "Firmware Upgrade available"
         )
         self._attr_unique_id = f"{self._pet_id}_firmware_upgrade"
-        self._pet_data = pet
         self._attr_translation_key = "firmware_upgrade_available"
 
     @property
     def is_on(self) -> bool:
         return bool(self._pet_data.get("firmware_need_upgrade"))
-
-    def _handle_coordinator_update(self) -> None:
-        for pet in self.coordinator.data.get("pets", []):
-            if pet.get("petID") == self._pet_id:
-                self._pet_data = pet
-                break
-        super()._handle_coordinator_update()
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)

--- a/custom_components/kippy/button.py
+++ b/custom_components/kippy/button.py
@@ -10,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import (
@@ -18,6 +17,7 @@ from .coordinator import (
     KippyDataUpdateCoordinator,
     KippyMapDataUpdateCoordinator,
 )
+from .entity import KippyMapEntity
 from .helpers import build_device_info
 
 
@@ -44,16 +44,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class KippyRefreshMapAttributesButton(
-    CoordinatorEntity[KippyMapDataUpdateCoordinator], ButtonEntity
-):
+class KippyRefreshMapAttributesButton(KippyMapEntity, ButtonEntity):
     """Button to refresh Kippy map attributes immediately."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
+        super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = (
             f"{pet_name} Refresh Map Attributes"
@@ -62,7 +59,6 @@ class KippyRefreshMapAttributesButton(
         )
         self._attr_unique_id = f"{self._pet_id}_refresh_map_attributes"
         self._pet_name = pet_name
-        self._pet_data = pet
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_translation_key = "refresh_map_attributes"
 
@@ -74,11 +70,6 @@ class KippyRefreshMapAttributesButton(
         raise NotImplementedError(
             "Synchronous button presses are not supported; use async_press instead."
         )
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
 
 
 class KippyActivityCategoriesButton(ButtonEntity):
@@ -110,9 +101,7 @@ class KippyActivityCategoriesButton(ButtonEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
+        return build_device_info(self._pet_id, self._pet_data)
 
 
 class KippyRefreshPetsButton(ButtonEntity):

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import inspect
 import logging
-from asyncio import TimeoutError as AsyncioTimeoutError
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from json import JSONDecodeError
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
-from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_point_in_utc_time
@@ -24,12 +22,22 @@ from .const import (
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
 )
+from .helpers import API_EXCEPTIONS, MapRefreshSettings
 
 _LOGGER = logging.getLogger(__name__)
 
 _HAS_CONFIG_ENTRY = (
     "config_entry" in inspect.signature(DataUpdateCoordinator.__init__).parameters
 )
+
+
+@dataclass(slots=True)
+class CoordinatorContext:
+    """Container for coordinator dependencies."""
+
+    hass: HomeAssistant
+    config_entry: ConfigEntry
+    api: KippyApi
 
 
 class KippyDataUpdateCoordinator(DataUpdateCoordinator):
@@ -56,12 +64,7 @@ class KippyDataUpdateCoordinator(DataUpdateCoordinator):
         # ``get_pet_kippy_list`` internally ensures a valid login session.
         try:
             return {"pets": await self.api.get_pet_kippy_list()}
-        except (
-            ClientError,
-            AsyncioTimeoutError,
-            RuntimeError,
-            JSONDecodeError,
-        ) as err:
+        except API_EXCEPTIONS as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
 
@@ -70,38 +73,31 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(
         self,
-        hass: HomeAssistant,
-        config_entry: ConfigEntry,
-        api: KippyApi,
+        context: CoordinatorContext,
         kippy_id: int,
-        idle_refresh: int = 300,
-        live_refresh: int = 10,
+        settings: MapRefreshSettings | None = None,
     ) -> None:
         """Initialize the map coordinator."""
-        self.api = api
-        self.config_entry = config_entry
+        self.api = context.api
+        self.config_entry = context.config_entry
         self.kippy_id = kippy_id
-        self.idle_refresh = idle_refresh
-        self.live_refresh = live_refresh
+        refresh = settings or MapRefreshSettings()
+        self.idle_refresh = refresh.idle_seconds
+        self.live_refresh = refresh.live_seconds
         self.ignore_lbs = True
         kwargs: dict[str, Any] = {
             "name": f"{DOMAIN}_{kippy_id}_map",
             "update_interval": timedelta(seconds=self.idle_refresh),
         }
         if _HAS_CONFIG_ENTRY:
-            kwargs["config_entry"] = config_entry
-        super().__init__(hass, _LOGGER, **kwargs)
+            kwargs["config_entry"] = context.config_entry
+        super().__init__(context.hass, _LOGGER, **kwargs)
 
     async def _async_update_data(self):
         """Fetch location data and adjust the refresh interval."""
         try:
             data = await self.api.kippymap_action(self.kippy_id)
-        except (
-            ClientError,
-            AsyncioTimeoutError,
-            RuntimeError,
-            JSONDecodeError,
-        ) as err:
+        except API_EXCEPTIONS as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         return self._process_data(data)
 
@@ -174,22 +170,20 @@ class KippyActivityCategoriesDataUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(
         self,
-        hass: HomeAssistant,
-        config_entry: ConfigEntry,
-        api: KippyApi,
-        pet_ids: list[int],
+        context: CoordinatorContext,
+        pet_ids: Iterable[int | str],
     ) -> None:
         """Initialize the activity categories coordinator."""
-        self.api = api
-        self.config_entry = config_entry
-        self.pet_ids = pet_ids
+        self.api = context.api
+        self.config_entry = context.config_entry
+        self.pet_ids = list(pet_ids)
         kwargs: dict[str, Any] = {
             "name": f"{DOMAIN}_activities",
             "update_interval": None,
         }
         if _HAS_CONFIG_ENTRY:
-            kwargs["config_entry"] = config_entry
-        super().__init__(hass, _LOGGER, **kwargs)
+            kwargs["config_entry"] = context.config_entry
+        super().__init__(context.hass, _LOGGER, **kwargs)
 
     async def _async_update_data(self) -> dict[int, dict[str, Any]]:
         """Fetch activity categories for all configured pets."""
@@ -202,16 +196,11 @@ class KippyActivityCategoriesDataUpdateCoordinator(DataUpdateCoordinator):
                 data[pet_id] = await self.api.get_activity_categories(
                     pet_id, from_date, to_date, 2, 1
                 )
-        except (
-            ClientError,
-            AsyncioTimeoutError,
-            RuntimeError,
-            JSONDecodeError,
-        ) as err:
+        except API_EXCEPTIONS as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         return data
 
-    async def async_refresh_pet(self, pet_id: int) -> None:
+    async def async_refresh_pet(self, pet_id: int | str) -> None:
         """Manually refresh activity data for a single pet."""
         now = dt_util.now()
         from_date = now.strftime("%Y-%m-%d")
@@ -223,17 +212,27 @@ class KippyActivityCategoriesDataUpdateCoordinator(DataUpdateCoordinator):
         new_data[pet_id] = result
         self.async_set_updated_data(new_data)
 
-    def get_activities(self, pet_id: int):
+    def get_activities(self, pet_id: int | str):
         """Return cached activities for the given pet."""
         return (self.data or {}).get(pet_id, {}).get("activities")
 
-    def get_avg(self, pet_id: int):
+    def get_avg(self, pet_id: int | str):
         """Return cached averages for the given pet."""
         return (self.data or {}).get(pet_id, {}).get("avg")
 
-    def get_health(self, pet_id: int):
+    def get_health(self, pet_id: int | str):
         """Return cached health information for the given pet."""
         return (self.data or {}).get(pet_id, {}).get("health")
+
+
+@dataclass(slots=True)
+class ActivityRefreshContext:
+    """Context used by ``ActivityRefreshTimer``."""
+
+    hass: HomeAssistant
+    base: "KippyDataUpdateCoordinator"
+    map: "KippyMapDataUpdateCoordinator"
+    activity: "KippyActivityCategoriesDataUpdateCoordinator"
 
 
 class ActivityRefreshTimer:
@@ -241,28 +240,32 @@ class ActivityRefreshTimer:
 
     def __init__(
         self,
-        hass: HomeAssistant,
-        base_coordinator: KippyDataUpdateCoordinator,
-        map_coordinator: KippyMapDataUpdateCoordinator,
-        activity_coordinator: KippyActivityCategoriesDataUpdateCoordinator,
-        pet_id: int,
+        context: ActivityRefreshContext,
+        pet_id: int | str,
         delay_minutes: int = DEFAULT_ACTIVITY_REFRESH_DELAY,
     ) -> None:
         """Initialize the timer."""
-        self.hass = hass
-        self.base_coordinator = base_coordinator
-        self.map_coordinator = map_coordinator
-        self.activity_coordinator = activity_coordinator
-        self.pet_id = pet_id
-        self.delay_minutes = delay_minutes
+        self._context = context
+        self._pet_id = pet_id
+        self._delay_minutes = delay_minutes
         self._unsub_timer: Callable[[], None] | None = None
-        self._unsub_base = base_coordinator.async_add_listener(self._schedule_refresh)
-        self._unsub_map = map_coordinator.async_add_listener(self._schedule_refresh)
+        self._listeners: list[Callable[[], None]] = []
+        for coordinator in (context.base, context.map):
+            self._listeners.append(
+                coordinator.async_add_listener(self._schedule_refresh)
+            )
         self._schedule_refresh()
 
+    @property
+    def delay_minutes(self) -> int:
+        """Return the configured delay in minutes."""
+
+        return self._delay_minutes
+
     def _get_update_frequency(self) -> int | None:
-        for pet in self.base_coordinator.data.get("pets", []):
-            if pet.get("petID") == self.pet_id:
+        pets = (self._context.base.data or {}).get("pets", [])
+        for pet in pets:
+            if pet.get("petID") == self._pet_id:
                 return pet.get("updateFrequency")
         return None
 
@@ -271,8 +274,8 @@ class ActivityRefreshTimer:
             self._unsub_timer()
             self._unsub_timer = None
         contact = (
-            self.map_coordinator.data.get("contact_time")
-            if self.map_coordinator.data
+            self._context.map.data.get("contact_time")
+            if self._context.map.data
             else None
         )
         update_frequency = self._get_update_frequency()
@@ -280,34 +283,35 @@ class ActivityRefreshTimer:
             return
         try:
             when = datetime.fromtimestamp(
-                int(contact) + int(update_frequency) * 3600 + self.delay_minutes * 60,
+                int(contact) + int(update_frequency) * 3600 + self._delay_minutes * 60,
                 timezone.utc,
             )
         except (TypeError, ValueError, OSError):
             return
         now = dt_util.utcnow()
         if when <= now:
-            when = now + timedelta(minutes=self.delay_minutes)
+            when = now + timedelta(minutes=self._delay_minutes)
         self._unsub_timer = async_track_point_in_utc_time(
-            self.hass, self._handle_refresh, when
+            self._context.hass, self._handle_refresh, when
         )
 
     async def _handle_refresh(self, _now) -> None:
         self._unsub_timer = None
-        await self.activity_coordinator.async_refresh_pet(self.pet_id)
-        await self.map_coordinator.async_request_refresh()
+        await self._context.activity.async_refresh_pet(self._pet_id)
+        await self._context.map.async_request_refresh()
 
     async def async_set_delay(self, minutes: int) -> None:
-        self.delay_minutes = minutes
+        """Update the delay between refreshes."""
+
+        self._delay_minutes = minutes
         self._schedule_refresh()
 
     def async_cancel(self) -> None:
+        """Cancel scheduled refreshes and coordinator listeners."""
+
         if self._unsub_timer:
             self._unsub_timer()
             self._unsub_timer = None
-        if self._unsub_base:
-            self._unsub_base()
-            self._unsub_base = None
-        if self._unsub_map:
-            self._unsub_map()
-            self._unsub_map = None
+        for unsub in self._listeners:
+            unsub()
+        self._listeners.clear()

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -7,12 +7,10 @@ from typing import Any
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LABEL_EXPIRED, PET_KIND_TO_TYPE
 from .coordinator import KippyMapDataUpdateCoordinator
-from .helpers import build_device_info
+from .entity import KippyMapEntity
 
 
 async def async_setup_entry(
@@ -30,15 +28,14 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerEntity):
+class KippyPetTracker(KippyMapEntity, TrackerEntity):
     """Representation of a Kippy tracked pet."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
         """Initialize the tracker entity."""
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
+        super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = f"Kippy {pet_name}" if pet_name else "Kippy"
         self._attr_unique_id = pet["petID"]
@@ -139,8 +136,3 @@ class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerE
             return int(val)
         except (TypeError, ValueError):
             return None
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for this pet."""
-        return build_device_info(self._pet_id, self._pet_data, self._attr_name)

--- a/custom_components/kippy/entity.py
+++ b/custom_components/kippy/entity.py
@@ -1,0 +1,52 @@
+"""Shared base entities for the Kippy integration."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import KippyDataUpdateCoordinator, KippyMapDataUpdateCoordinator
+from .helpers import build_device_info, update_pet_data
+
+
+class KippyPetEntity(CoordinatorEntity[KippyDataUpdateCoordinator]):
+    """Base entity for pet-specific coordinator data."""
+
+    _preserve_fields: Sequence[str] = ()
+
+    def __init__(
+        self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]
+    ) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_data = pet
+
+    def _handle_coordinator_update(self) -> None:
+        self._pet_data = update_pet_data(
+            self.coordinator.data.get("pets", []),
+            self._pet_id,
+            self._pet_data,
+            self._preserve_fields,
+        )
+        super()._handle_coordinator_update()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._pet_id, self._pet_data)
+
+
+class KippyMapEntity(CoordinatorEntity[KippyMapDataUpdateCoordinator]):
+    """Base entity for map coordinator data."""
+
+    def __init__(
+        self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
+    ) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_data = pet
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return build_device_info(self._pet_id, self._pet_data)

--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -1,14 +1,52 @@
+"""Helper utilities for the Kippy integration."""
+
 from __future__ import annotations
 
-from typing import Any
+from asyncio import TimeoutError as AsyncioTimeoutError
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from json import JSONDecodeError
+from typing import Any, cast
 
+from aiohttp import ClientError
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN
 
+API_EXCEPTIONS: tuple[type[Exception], ...] = (
+    ClientError,
+    AsyncioTimeoutError,
+    RuntimeError,
+    JSONDecodeError,
+)
 
-def build_device_info(pet_id: int | str, pet: dict[str, Any], name: str) -> DeviceInfo:
+MAP_REFRESH_OPTIONS_KEY = "map_refresh_settings"
+MAP_REFRESH_IDLE_KEY = "idle_seconds"
+MAP_REFRESH_LIVE_KEY = "live_seconds"
+
+
+@dataclass(slots=True)
+class MapRefreshSettings:
+    """Persisted refresh configuration for a pet's map coordinator."""
+
+    idle_seconds: int = 300
+    live_seconds: int = 10
+
+
+def build_device_name(pet: Mapping[str, Any], prefix: str = "Kippy") -> str:
+    """Return a display name for a pet."""
+
+    pet_name = pet.get("petName")
+    return f"{prefix} {pet_name}" if pet_name else prefix
+
+
+def build_device_info(
+    pet_id: int | str, pet: Mapping[str, Any], name: str | None = None
+) -> DeviceInfo:
     """Create a DeviceInfo object for a Kippy pet."""
+
     identifiers: set[tuple[str, str]] = {(DOMAIN, str(pet_id))}
     connections: set[tuple[str, str]] = set()
 
@@ -27,9 +65,157 @@ def build_device_info(pet_id: int | str, pet: dict[str, Any], name: str) -> Devi
     return DeviceInfo(
         identifiers=identifiers,
         connections=connections or None,
-        name=name,
+        name=name or build_device_name(pet),
         manufacturer="Kippy",
         model=pet.get("kippyType"),
         sw_version=pet.get("kippyFirmware"),
         serial_number=kippy_serial,
     )
+
+
+def is_pet_subscription_active(pet: Mapping[str, Any]) -> bool:
+    """Return ``True`` if the pet's subscription is active."""
+
+    expired_days = pet.get("expired_days")
+    try:
+        return int(expired_days) < 0
+    except (TypeError, ValueError):
+        return True
+
+
+def normalize_kippy_identifier(
+    pet: Mapping[str, Any], *, include_pet_id: bool = False
+) -> int | None:
+    """Return the numeric Kippy identifier for ``pet`` if present."""
+
+    identifier = pet.get("kippyID") or pet.get("kippy_id")
+    if identifier is None and include_pet_id:
+        identifier = pet.get("petID")
+    if identifier is None:
+        return None
+    try:
+        return int(identifier)
+    except (TypeError, ValueError):
+        return None
+
+
+def update_pet_data(
+    pets: Iterable[Mapping[str, Any]],
+    pet_id: int | str,
+    current: MutableMapping[str, Any],
+    preserve: Sequence[str] | None = None,
+) -> MutableMapping[str, Any]:
+    """Return the latest pet data from ``pets`` preserving ``preserve`` keys."""
+
+    preserve = tuple(preserve or ())
+    for pet in pets:
+        if pet.get("petID") != pet_id:
+            continue
+        if preserve:
+            for field in preserve:
+                if field in current and field not in pet:
+                    pet[field] = current[field]
+        return cast(MutableMapping[str, Any], pet)
+    return current
+
+
+def _normalize_refresh_value(value: Any) -> int | None:
+    """Return ``value`` as a positive integer seconds value when valid."""
+
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return None
+    if result <= 0:
+        return None
+    return result
+
+
+def get_map_refresh_settings(
+    entry: ConfigEntry, pet_id: int | str
+) -> MapRefreshSettings | None:
+    """Return stored map refresh settings for ``pet_id`` if available."""
+
+    options = entry.options.get(MAP_REFRESH_OPTIONS_KEY)
+    if not isinstance(options, Mapping):
+        return None
+    pet_options = options.get(str(pet_id))
+    if not isinstance(pet_options, Mapping):
+        return None
+
+    idle_seconds = _normalize_refresh_value(pet_options.get(MAP_REFRESH_IDLE_KEY))
+    live_seconds = _normalize_refresh_value(pet_options.get(MAP_REFRESH_LIVE_KEY))
+
+    if idle_seconds is None and live_seconds is None:
+        return None
+
+    settings = MapRefreshSettings()
+    if idle_seconds is not None:
+        settings.idle_seconds = idle_seconds
+    if live_seconds is not None:
+        settings.live_seconds = live_seconds
+    return settings
+
+
+def _collect_refresh_updates(
+    idle_seconds: int | None, live_seconds: int | None
+) -> dict[str, int]:
+    """Return a mapping of updated idle/live refresh values in seconds."""
+
+    updates: dict[str, int] = {}
+    if idle_seconds is not None:
+        normalized_idle = _normalize_refresh_value(idle_seconds)
+        if normalized_idle is not None:
+            updates[MAP_REFRESH_IDLE_KEY] = normalized_idle
+    if live_seconds is not None:
+        normalized_live = _normalize_refresh_value(live_seconds)
+        if normalized_live is not None:
+            updates[MAP_REFRESH_LIVE_KEY] = normalized_live
+    return updates
+
+
+def _copy_map_refresh_options(entry: ConfigEntry) -> dict[str, dict[str, Any]]:
+    """Return a mutable copy of stored map refresh settings."""
+
+    copied: dict[str, dict[str, Any]] = {}
+    existing = entry.options.get(MAP_REFRESH_OPTIONS_KEY)
+    if not isinstance(existing, Mapping):
+        return copied
+    for key, value in existing.items():
+        if isinstance(key, str) and isinstance(value, Mapping):
+            copied[key] = dict(value)
+    return copied
+
+
+async def async_update_map_refresh_settings(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    pet_id: int | str,
+    *,
+    idle_seconds: int | None = None,
+    live_seconds: int | None = None,
+) -> None:
+    """Persist updated map refresh settings for ``pet_id``."""
+
+    updates = _collect_refresh_updates(idle_seconds, live_seconds)
+    if not updates:
+        return
+
+    pet_key = str(pet_id)
+    map_options = _copy_map_refresh_options(entry)
+    pet_options = map_options.get(pet_key, {}).copy()
+
+    changed = False
+    for option_key, option_value in updates.items():
+        if pet_options.get(option_key) != option_value:
+            pet_options[option_key] = option_value
+            changed = True
+
+    if not changed:
+        return
+
+    map_options[pet_key] = pet_options
+    new_options = dict(entry.options)
+    new_options[MAP_REFRESH_OPTIONS_KEY] = map_options
+
+    await hass.config_entries.async_update_entry(entry, options=new_options)

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any, Mapping
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -26,7 +27,18 @@ from .coordinator import (
     KippyDataUpdateCoordinator,
     KippyMapDataUpdateCoordinator,
 )
-from .helpers import build_device_info
+from .entity import KippyMapEntity, KippyPetEntity
+from .helpers import build_device_info, is_pet_subscription_active, update_pet_data
+
+_TIME_UNITS = {
+    UnitOfTime.MICROSECONDS,
+    UnitOfTime.MILLISECONDS,
+    UnitOfTime.SECONDS,
+    UnitOfTime.MINUTES,
+    UnitOfTime.HOURS,
+    UnitOfTime.DAYS,
+    UnitOfTime.WEEKS,
+}
 
 
 async def async_setup_entry(
@@ -45,14 +57,7 @@ async def async_setup_entry(
         entities.append(KippyIDSensor(coordinator, pet))
         entities.append(KippyIMEISensor(coordinator, pet))
 
-        expired_days = pet.get("expired_days")
-        is_expired = False
-        try:
-            is_expired = int(expired_days) >= 0
-        except (TypeError, ValueError):
-            pass
-
-        if not is_expired:
+        if is_pet_subscription_active(pet):
             entities.append(KippyEnergySavingStatusSensor(coordinator, pet))
             entities.append(KippyPetTypeSensor(coordinator, pet))
             map_coord = map_coordinators.get(pet["petID"])
@@ -88,38 +93,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class _KippyBaseEntity(CoordinatorEntity[KippyDataUpdateCoordinator]):
+class _KippyBaseEntity(KippyPetEntity, SensorEntity):
     """Base entity for Kippy sensors."""
 
-    def __init__(
-        self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]
-    ) -> None:
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
-        self._pet_data = pet
-
-    def _handle_coordinator_update(self) -> None:
-        for pet in self.coordinator.data.get("pets", []):
-            if pet.get("petID") == self._pet_id:
-                if (
-                    self._pet_data.get("energySavingModePending")
-                    and "energySavingModePending" not in pet
-                ):
-                    pet["energySavingModePending"] = self._pet_data[
-                        "energySavingModePending"
-                    ]
-                self._pet_data = pet
-                break
-        super()._handle_coordinator_update()
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
+    _preserve_fields = ("energySavingModePending",)
 
 
-class KippyExpiredDaysSensor(_KippyBaseEntity, SensorEntity):
+class KippyExpiredDaysSensor(_KippyBaseEntity):
     """Sensor for remaining service days."""
 
     def __init__(
@@ -168,7 +148,7 @@ class KippyExpiredDaysSensor(_KippyBaseEntity, SensorEntity):
         return remaining
 
 
-class KippyPetTypeSensor(_KippyBaseEntity, SensorEntity):
+class KippyPetTypeSensor(_KippyBaseEntity):
     """Sensor for pet type."""
 
     def __init__(
@@ -186,7 +166,7 @@ class KippyPetTypeSensor(_KippyBaseEntity, SensorEntity):
         return PET_KIND_TO_TYPE.get(str(kind))
 
 
-class KippyIDSensor(_KippyBaseEntity, SensorEntity):
+class KippyIDSensor(_KippyBaseEntity):
     """Diagnostic sensor for the Kippy device ID."""
 
     def __init__(
@@ -203,7 +183,7 @@ class KippyIDSensor(_KippyBaseEntity, SensorEntity):
         return self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
 
 
-class KippyIMEISensor(_KippyBaseEntity, SensorEntity):
+class KippyIMEISensor(_KippyBaseEntity):
     """Diagnostic sensor for the device IMEI."""
 
     def __init__(
@@ -220,41 +200,45 @@ class KippyIMEISensor(_KippyBaseEntity, SensorEntity):
         return self._pet_data.get("kippyIMEI")
 
 
+@dataclass(slots=True)
+class ActivitySensorDescription:
+    """Description of a daily activity sensor."""
+
+    metric: str
+    name: str
+    unit: str | None = None
+    device_class: SensorDeviceClass | str | None = None
+
+
 class _KippyActivitySensor(
     CoordinatorEntity[KippyActivityCategoriesDataUpdateCoordinator], SensorEntity
 ):
     """Base class for daily activity sensors."""
 
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(
         self,
         coordinator: KippyActivityCategoriesDataUpdateCoordinator,
         pet: dict[str, Any],
-        metric: str,
-        name: str,
-        unit: str | None = None,
-        device_class: SensorDeviceClass | str | None = None,
+        description: ActivitySensorDescription,
     ) -> None:
         super().__init__(coordinator)
         self._pet_id = pet["petID"]
         self._pet_data = pet
-        self._metric = metric
+        self._description = description
         pet_name = pet.get("petName")
-        self._attr_name = f"{pet_name} {name}" if pet_name else name
-        self._attr_unique_id = f"{self._pet_id}_{metric}"
-        self._source_unit = unit
-        self._attr_native_unit_of_measurement = unit
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        if device_class:
-            self._attr_device_class = device_class
-        if device_class == SensorDeviceClass.DURATION:
-            self._attr_suggested_unit_of_measurement = UnitOfTime.HOURS
+        self._attr_name = (
+            f"{pet_name} {description.name}" if pet_name else description.name
+        )
+        self._attr_unique_id = f"{self._pet_id}_{description.metric}"
+        if description.device_class:
+            self._attr_device_class = description.device_class
         self._date: str | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
+        return build_device_info(self._pet_id, self._pet_data)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -263,81 +247,124 @@ class _KippyActivitySensor(
         return None
 
     @property
+    def suggested_unit_of_measurement(self) -> str | None:
+        if self._description.device_class == SensorDeviceClass.DURATION:
+            return UnitOfTime.HOURS
+        return None
+
+    @property
     def native_value(self) -> Any:
         activities = self.coordinator.get_activities(self._pet_id)
         if not activities:
             return None
         today = dt_util.now()
-        value: Any = None
+        if self._activities_grouped_by_metric(activities):
+            value, date_str = self._value_from_grouped_activities(activities, today)
+        else:
+            value, date_str = self._value_from_daily_entries(activities, today)
+        if value is None:
+            return None
+        self._date = date_str
+        return self._convert_activity_value(value)
 
-        # Cat trackers return data grouped by activity rather than by day.
-        if isinstance(activities, list) and activities and "activity" in activities[0]:
-            today_prefix = today.strftime("%Y%m%d")
-            for activity in activities:
-                if activity.get("activity") != self._metric:
+    def _activities_grouped_by_metric(self, activities: Any) -> bool:
+        return bool(
+            isinstance(activities, list)
+            and activities
+            and isinstance(activities[0], dict)
+            and "activity" in activities[0]
+        )
+
+    def _value_from_grouped_activities(
+        self, activities: list[dict[str, Any]], today: datetime
+    ) -> tuple[float | int | None, str | None]:
+        today_prefix = today.strftime("%Y%m%d")
+        for activity in activities:
+            if activity.get("activity") != self._description.metric:
+                continue
+            total = 0.0
+            for entry in activity.get("data", []):
+                time_caption = str(entry.get("timeCaption") or "")
+                if not time_caption.startswith(today_prefix):
                     continue
-                total: float | int = 0
-                for entry in activity.get("data", []):
-                    time_caption = str(entry.get("timeCaption") or "")
-                    if not time_caption.startswith(today_prefix):
-                        continue
-                    for key in (
+                numeric = self._extract_numeric_value(
+                    entry,
+                    (
                         "valueMinutes",
                         "value",
                         "count",
                         "minutes",
                         "duration",
                         "total",
-                    ):
-                        if key in entry:
-                            try:
-                                total += int(entry[key])
-                            except (TypeError, ValueError):
-                                try:
-                                    total += float(entry[key])
-                                except (TypeError, ValueError):
-                                    pass
-                            break
-                value = total
-                self._date = today.strftime("%Y-%m-%d")
-                break
-        else:
-            today_str = today.strftime("%Y-%m-%d")
-            for item in activities:
-                item_date = (
-                    item.get("date")
-                    or item.get("day")
-                    or item.get("date_time")
-                    or item.get("datetime")
+                    ),
                 )
-                if item_date != today_str:
-                    continue
-                data = item.get(self._metric)
-                if data is None and isinstance(item.get("activities"), list):
-                    for cat in item["activities"]:
-                        if (
-                            cat.get("name") == self._metric
-                            or cat.get("type") == self._metric
-                        ):
-                            data = (
-                                cat.get("value")
-                                or cat.get("count")
-                                or cat.get("minutes")
-                                or cat.get("duration")
-                                or cat.get("total")
-                            )
-                            break
-                if isinstance(data, dict):
-                    for key in ("value", "count", "minutes", "duration", "total"):
-                        if key in data:
-                            data = data[key]
-                            break
-                value = data
-                self._date = item_date
-                break
+                if numeric is not None:
+                    total += numeric
+            return total, today.strftime("%Y-%m-%d")
+        return None, None
 
-        if value is None:
-            return None
+    def _value_from_daily_entries(
+        self, activities: Any, today: datetime
+    ) -> tuple[Any, str | None]:
+        today_str = today.strftime("%Y-%m-%d")
+        for item in activities:
+            item_date = self._extract_date(item)
+            if item_date != today_str:
+                continue
+            data = item.get(self._description.metric)
+            if data is None and isinstance(item.get("activities"), list):
+                data = self._value_from_activity_list(item["activities"])
+            if isinstance(data, dict):
+                data = self._extract_first_present(
+                    data, ("value", "count", "minutes", "duration", "total")
+                )
+            return data, item_date
+        return None, None
+
+    def _value_from_activity_list(self, activities: list[dict[str, Any]]) -> Any:
+        for entry in activities:
+            if (
+                entry.get("name") == self._description.metric
+                or entry.get("type") == self._description.metric
+            ):
+                return self._extract_first_present(
+                    entry, ("value", "count", "minutes", "duration", "total")
+                )
+        return None
+
+    @staticmethod
+    def _extract_date(item: Mapping[str, Any]) -> str | None:
+        for key in ("date", "day", "date_time", "datetime"):
+            value = item.get(key)
+            if value:
+                return str(value)
+        return None
+
+    @staticmethod
+    def _extract_first_present(data: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
+        for key in keys:
+            if key in data:
+                return data[key]
+        return None
+
+    @staticmethod
+    def _extract_numeric_value(
+        data: Mapping[str, Any], keys: tuple[str, ...]
+    ) -> float | None:
+        for key in keys:
+            if key not in data:
+                continue
+            value = data[key]
+            try:
+                return float(int(value))
+            except (TypeError, ValueError):
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        return None
+
+    def _convert_activity_value(self, value: Any) -> float | int | None:
         try:
             numeric: float | int = int(value)
         except (TypeError, ValueError):
@@ -345,40 +372,23 @@ class _KippyActivitySensor(
                 numeric = float(value)
             except (TypeError, ValueError):
                 return None
-        if self._source_unit in {
-            UnitOfTime.MICROSECONDS,
-            UnitOfTime.MILLISECONDS,
-            UnitOfTime.SECONDS,
-            UnitOfTime.MINUTES,
-            UnitOfTime.HOURS,
-            UnitOfTime.DAYS,
-            UnitOfTime.WEEKS,
-        }:
+        unit = self._description.unit
+        if unit in _TIME_UNITS:
             target_unit = self.native_unit_of_measurement
-            if target_unit != self._source_unit:
-                return DurationConverter.convert(
-                    numeric, self._source_unit, target_unit
-                )
+            if target_unit != unit:
+                return DurationConverter.convert(numeric, unit, target_unit)
         return numeric
 
     @property
     def native_unit_of_measurement(self) -> str | None:
-        if self._source_unit in {
-            UnitOfTime.MICROSECONDS,
-            UnitOfTime.MILLISECONDS,
-            UnitOfTime.SECONDS,
-            UnitOfTime.MINUTES,
-            UnitOfTime.HOURS,
-            UnitOfTime.DAYS,
-            UnitOfTime.WEEKS,
-        }:
-            if self.hass:
-                unit = self.hass.config.units.get_converted_unit(
-                    SensorDeviceClass.DURATION, self._source_unit
-                )
-                if unit:
-                    return unit
-        return self._source_unit
+        unit = self._description.unit
+        if unit in _TIME_UNITS and self.hass:
+            converted = self.hass.config.units.get_converted_unit(
+                SensorDeviceClass.DURATION, unit
+            )
+            if converted:
+                return converted
+        return unit
 
 
 class KippyStepsSensor(_KippyActivitySensor):
@@ -389,7 +399,11 @@ class KippyStepsSensor(_KippyActivitySensor):
         coordinator: KippyActivityCategoriesDataUpdateCoordinator,
         pet: dict[str, Any],
     ) -> None:
-        super().__init__(coordinator, pet, "steps", "Steps", "steps")
+        super().__init__(
+            coordinator,
+            pet,
+            ActivitySensorDescription("steps", "Steps", "steps"),
+        )
 
 
 class KippyCaloriesSensor(_KippyActivitySensor):
@@ -400,7 +414,11 @@ class KippyCaloriesSensor(_KippyActivitySensor):
         coordinator: KippyActivityCategoriesDataUpdateCoordinator,
         pet: dict[str, Any],
     ) -> None:
-        super().__init__(coordinator, pet, "calories", "Calories", "kcal")
+        super().__init__(
+            coordinator,
+            pet,
+            ActivitySensorDescription("calories", "Calories", "kcal"),
+        )
 
 
 class KippyRunSensor(_KippyActivitySensor):
@@ -414,10 +432,9 @@ class KippyRunSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "run",
-            "Run",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "run", "Run", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -432,10 +449,9 @@ class KippyWalkSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "walk",
-            "Walk",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "walk", "Walk", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -450,10 +466,9 @@ class KippySleepSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "sleep",
-            "Sleep",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "sleep", "Sleep", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -468,10 +483,9 @@ class KippyRestSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "rest",
-            "Rest",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "rest", "Rest", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -486,10 +500,9 @@ class KippyPlaySensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "play",
-            "Play",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "play", "Play", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -504,10 +517,9 @@ class KippyRelaxSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "relax",
-            "Relax",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "relax", "Relax", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -519,7 +531,9 @@ class KippyJumpsSensor(_KippyActivitySensor):
         coordinator: KippyActivityCategoriesDataUpdateCoordinator,
         pet: dict[str, Any],
     ) -> None:
-        super().__init__(coordinator, pet, "jumps", "Jumps", "jumps")
+        super().__init__(
+            coordinator, pet, ActivitySensorDescription("jumps", "Jumps", "jumps")
+        )
 
 
 class KippyClimbSensor(_KippyActivitySensor):
@@ -533,10 +547,9 @@ class KippyClimbSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "climb",
-            "Climb",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "climb", "Climb", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -551,10 +564,12 @@ class KippyGroomingSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "grooming",
-            "Grooming",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "grooming",
+                "Grooming",
+                UnitOfTime.MINUTES,
+                SensorDeviceClass.DURATION,
+            ),
         )
 
 
@@ -569,10 +584,9 @@ class KippyEatSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "eat",
-            "Eat",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "eat", "Eat", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
@@ -587,22 +601,32 @@ class KippyDrinkSensor(_KippyActivitySensor):
         super().__init__(
             coordinator,
             pet,
-            "drink",
-            "Drink",
-            UnitOfTime.MINUTES,
-            SensorDeviceClass.DURATION,
+            ActivitySensorDescription(
+                "drink", "Drink", UnitOfTime.MINUTES, SensorDeviceClass.DURATION
+            ),
         )
 
 
-class KippyBatterySensor(
-    CoordinatorEntity[KippyMapDataUpdateCoordinator], SensorEntity
-):
+class _KippyBaseMapEntity(KippyMapEntity, SensorEntity):
+    """Base entity for map-based sensors."""
+
+    def _get_datetime(self, key: str) -> datetime | None:
+        if not self.coordinator.data:
+            return None
+        ts = self.coordinator.data.get(key)
+        try:
+            return datetime.fromtimestamp(int(ts), timezone.utc)
+        except (TypeError, ValueError, OSError):
+            return None
+
+
+class KippyBatterySensor(_KippyBaseMapEntity):
     """Sensor for device battery level."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
-        super().__init__(coordinator)
+        super().__init__(coordinator, pet)
         self._pet_id = pet["petID"]
         self._pet_data = pet
         pet_name = pet.get("petName")
@@ -611,12 +635,6 @@ class KippyBatterySensor(
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
 
     @property
     def native_value(self) -> Any:
@@ -629,15 +647,13 @@ class KippyBatterySensor(
             return None
 
 
-class KippyLocalizationTechnologySensor(
-    CoordinatorEntity[KippyMapDataUpdateCoordinator], SensorEntity
-):
+class KippyLocalizationTechnologySensor(_KippyBaseMapEntity):
     """Sensor for the technology used to determine location."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
-        super().__init__(coordinator)
+        super().__init__(coordinator, pet)
         self._pet_id = pet["petID"]
         self._pet_data = pet
         pet_name = pet.get("petName")
@@ -649,12 +665,6 @@ class KippyLocalizationTechnologySensor(
         self._attr_unique_id = f"{self._pet_id}_localization_technology"
 
     @property
-    def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
-
-    @property
     def native_value(self) -> Any:
         return (
             self.coordinator.data.get("localization_technology")
@@ -663,33 +673,7 @@ class KippyLocalizationTechnologySensor(
         )
 
 
-class _KippyBaseMapEntity(CoordinatorEntity[KippyMapDataUpdateCoordinator]):
-    """Base entity for map-based sensors."""
-
-    def __init__(
-        self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
-    ) -> None:
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
-        self._pet_data = pet
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
-
-    def _get_datetime(self, key: str) -> datetime | None:
-        if not self.coordinator.data:
-            return None
-        ts = self.coordinator.data.get(key)
-        try:
-            return datetime.fromtimestamp(int(ts), timezone.utc)
-        except (TypeError, ValueError, OSError):
-            return None
-
-
-class KippyLastContactSensor(_KippyBaseMapEntity, SensorEntity):
+class KippyLastContactSensor(_KippyBaseMapEntity):
     """Sensor for the time of the last contact with the server."""
 
     def __init__(
@@ -707,8 +691,12 @@ class KippyLastContactSensor(_KippyBaseMapEntity, SensorEntity):
         return self._get_datetime("contact_time")
 
 
-class KippyNextContactSensor(_KippyBaseMapEntity, SensorEntity):
+class KippyNextContactSensor(_KippyBaseMapEntity):
     """Sensor for the next scheduled contact."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "next_contact"
 
     def __init__(
         self,
@@ -718,27 +706,20 @@ class KippyNextContactSensor(_KippyBaseMapEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, pet)
         self._base_coordinator = base_coordinator
-        self._base_unsub: Callable[[], None] | None = None
-        self._base_unsub = base_coordinator.async_add_listener(self._handle_base_update)
+        self.async_on_remove(
+            base_coordinator.async_add_listener(self._handle_base_update)
+        )
         pet_name = pet.get("petName")
         self._attr_name = f"{pet_name} Next Contact" if pet_name else "Next Contact"
         self._attr_unique_id = f"{self._pet_id}_next_contact"
-        self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_translation_key = "next_contact"
 
     def _handle_base_update(self) -> None:
-        for pet in self._base_coordinator.data.get("pets", []):
-            if pet.get("petID") == self._pet_id:
-                self._pet_data = pet
-                break
+        self._pet_data = update_pet_data(
+            self._base_coordinator.data.get("pets", []),
+            self._pet_id,
+            self._pet_data,
+        )
         self.async_write_ha_state()
-
-    async def async_will_remove_from_hass(self) -> None:
-        if self._base_unsub:
-            self._base_unsub()
-            self._base_unsub = None
-        await super().async_will_remove_from_hass()
 
     @property
     def native_value(self) -> datetime | None:
@@ -756,7 +737,7 @@ class KippyNextContactSensor(_KippyBaseMapEntity, SensorEntity):
             return None
 
 
-class KippyLastFixSensor(_KippyBaseMapEntity, SensorEntity):
+class KippyLastFixSensor(_KippyBaseMapEntity):
     """Sensor for the time of the last location fix."""
 
     def __init__(
@@ -774,7 +755,7 @@ class KippyLastFixSensor(_KippyBaseMapEntity, SensorEntity):
         return self._get_datetime("fix_time")
 
 
-class KippyLastGpsFixSensor(_KippyBaseMapEntity, SensorEntity):
+class KippyLastGpsFixSensor(_KippyBaseMapEntity):
     """Sensor for the timestamp of the latest GPS fix."""
 
     def __init__(
@@ -796,7 +777,7 @@ class KippyLastGpsFixSensor(_KippyBaseMapEntity, SensorEntity):
         return self._get_datetime("gps_time")
 
 
-class KippyLastLbsFixSensor(_KippyBaseMapEntity, SensorEntity):
+class KippyLastLbsFixSensor(_KippyBaseMapEntity):
     """Sensor for the timestamp of the latest LBS fix."""
 
     def __init__(
@@ -814,18 +795,14 @@ class KippyLastLbsFixSensor(_KippyBaseMapEntity, SensorEntity):
         return self._get_datetime("lbs_time")
 
 
-class KippyOperatingStatusSensor(
-    CoordinatorEntity[KippyMapDataUpdateCoordinator], SensorEntity
-):
+class KippyOperatingStatusSensor(_KippyBaseMapEntity):
     """Sensor indicating operating status."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
+        super().__init__(coordinator, pet)
         self._pet_name = pet.get("petName")
-        self._pet_data = pet
         self._attr_name = (
             f"{self._pet_name} Operating Status"
             if self._pet_name
@@ -842,13 +819,8 @@ class KippyOperatingStatusSensor(
             else None
         )
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
 
-
-class KippyEnergySavingStatusSensor(_KippyBaseEntity, SensorEntity):
+class KippyEnergySavingStatusSensor(_KippyBaseEntity):
     """Sensor indicating energy saving status."""
 
     _attr_translation_key = "energy_saving_status"
@@ -876,9 +848,7 @@ class KippyEnergySavingStatusSensor(_KippyBaseEntity, SensorEntity):
         return "on" if is_on else "off"
 
 
-class KippyHomeDistanceSensor(
-    CoordinatorEntity[KippyMapDataUpdateCoordinator], SensorEntity
-):
+class KippyHomeDistanceSensor(_KippyBaseMapEntity):
     """Sensor for distance from Home Assistant's configured location."""
 
     _attr_device_class = SensorDeviceClass.DISTANCE
@@ -888,20 +858,12 @@ class KippyHomeDistanceSensor(
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
     ) -> None:
-        super().__init__(coordinator)
-        self._pet_id = pet["petID"]
-        self._pet_data = pet
+        super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = (
             f"{pet_name} Distance from Home" if pet_name else "Distance from Home"
         )
         self._attr_unique_id = f"{self._pet_id}_distance_from_home"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        pet_name = self._pet_data.get("petName")
-        name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return build_device_info(self._pet_id, self._pet_data, name)
 
     @property
     def native_unit_of_measurement(self) -> str:

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -17,15 +17,9 @@ from .const import (
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
 )
-from .coordinator import (
-    KippyDataUpdateCoordinator,
-    KippyMapDataUpdateCoordinator,
-)
+from .coordinator import KippyDataUpdateCoordinator, KippyMapDataUpdateCoordinator
 from .entity import KippyMapEntity, KippyPetEntity
-from .helpers import (
-    is_pet_subscription_active,
-    normalize_kippy_identifier,
-)
+from .helpers import is_pet_subscription_active, normalize_kippy_identifier
 
 
 async def async_setup_entry(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ pytest-homeassistant-custom-component==0.13.278
 aiohttp==3.12.15
 go2rtc-client==0.2.1
 PyTurboJPEG==1.8.0
+isort==5.13.2
 pre-commit==4.3.0
 python-dotenv==1.1.1
 pylint==3.3.8

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -195,3 +195,24 @@ def test_button_device_info_properties() -> None:
     activity = KippyActivityCategoriesButton(coordinator, pet)
     info2 = activity.device_info
     assert info2["name"] == "Kippy Rex"
+
+
+def test_buttons_raise_for_sync_press() -> None:
+    """Synchronous press methods are intentionally unsupported."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    map_button = KippyRefreshMapAttributesButton(coordinator, {"petID": 1})
+    with pytest.raises(NotImplementedError):
+        map_button.press()
+
+    activity_button = KippyActivityCategoriesButton(MagicMock(), {"petID": 2})
+    with pytest.raises(NotImplementedError):
+        activity_button.press()
+
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "1"
+    pets_button = KippyRefreshPetsButton(hass, entry)
+    with pytest.raises(NotImplementedError):
+        pets_button.press()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientError, ClientResponseError
+from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
 from custom_components.kippy.config_flow import KippyConfigFlow
@@ -36,6 +37,7 @@ async def test_config_flow_success() -> None:
             "cannot_connect",
         ),
         (ClientError(), "cannot_connect"),
+        (RuntimeError(), "unknown"),
         (Exception(), "unknown"),
     ],
 )
@@ -55,3 +57,15 @@ async def test_config_flow_errors(error: Exception, base: str) -> None:
         result = await flow.async_step_user({CONF_EMAIL: "user", CONF_PASSWORD: "pass"})
     assert result["type"].value == "form"
     assert result["errors"]["base"] == base
+
+
+def test_config_flow_is_matching() -> None:
+    """The flow matches other Kippy flows but not arbitrary ones."""
+
+    flow = KippyConfigFlow()
+    assert flow.is_matching(KippyConfigFlow())
+
+    class DummyFlow(config_entries.ConfigFlow):
+        pass
+
+    assert not flow.is_matching(DummyFlow())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,11 +11,19 @@ from custom_components.kippy.const import (
     OPERATING_STATUS_MAP,
 )
 from custom_components.kippy.coordinator import (
+    ActivityRefreshContext,
     ActivityRefreshTimer,
+    CoordinatorContext,
     KippyActivityCategoriesDataUpdateCoordinator,
     KippyDataUpdateCoordinator,
     KippyMapDataUpdateCoordinator,
 )
+
+
+def make_context(hass: MagicMock, api: MagicMock | None = None) -> CoordinatorContext:
+    """Return a coordinator context for tests."""
+
+    return CoordinatorContext(hass, MagicMock(), api or MagicMock())
 
 
 @pytest.mark.asyncio
@@ -23,7 +31,7 @@ async def test_process_new_data_maps_operating_status() -> None:
     """process_new_data should map numeric operating status codes."""
     hass = MagicMock()
     hass.loop = asyncio.get_running_loop()
-    coordinator = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+    coordinator = KippyMapDataUpdateCoordinator(make_context(hass), 1)
 
     coordinator.process_new_data({"operating_status": OPERATING_STATUS.ENERGY_SAVING})
 
@@ -62,7 +70,7 @@ async def test_map_coordinator_process_data_ignores_lbs() -> None:
     """LBS data is ignored and previous GPS data reused."""
     hass = MagicMock()
     hass.loop = asyncio.get_running_loop()
-    coord = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+    coord = KippyMapDataUpdateCoordinator(make_context(hass), 1)
     coord.ignore_lbs = True
     coord.data = {"gps_latitude": 5, "gps_longitude": 6}
     data = {
@@ -79,7 +87,7 @@ async def test_map_coordinator_set_refresh_updates_interval() -> None:
     """Setting refresh values updates coordinator interval based on status."""
     hass = MagicMock()
     hass.loop = asyncio.get_running_loop()
-    coord = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+    coord = KippyMapDataUpdateCoordinator(make_context(hass), 1)
     coord.data = {"operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]}
     await coord.async_set_live_refresh(20)
     assert coord.update_interval == timedelta(seconds=20)
@@ -97,7 +105,7 @@ async def test_map_coordinator_update_failure() -> None:
     hass.loop = asyncio.get_running_loop()
     api = MagicMock()
     api.kippymap_action = AsyncMock(side_effect=RuntimeError)
-    coord = KippyMapDataUpdateCoordinator(hass, MagicMock(), api, 1)
+    coord = KippyMapDataUpdateCoordinator(make_context(hass, api), 1)
     with pytest.raises(UpdateFailed):
         await coord._async_update_data()
 
@@ -107,7 +115,7 @@ async def test_process_data_without_existing_data_accepts_lbs() -> None:
     """LBS update with no previous data uses provided GPS keys."""
     hass = MagicMock()
     hass.loop = asyncio.get_running_loop()
-    coord = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+    coord = KippyMapDataUpdateCoordinator(make_context(hass), 1)
     coord.ignore_lbs = True
     data = {
         "localization_technology": LOCALIZATION_TECHNOLOGY_LBS,
@@ -123,7 +131,7 @@ async def test_process_data_without_existing_location_accepts_lbs() -> None:
     """LBS update accepted when existing data lacks GPS coordinates."""
     hass = MagicMock()
     hass.loop = asyncio.get_running_loop()
-    coord = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+    coord = KippyMapDataUpdateCoordinator(make_context(hass), 1)
     coord.ignore_lbs = True
     coord.data = {"operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]}
     data = {
@@ -140,7 +148,7 @@ async def test_process_data_live_sets_interval() -> None:
     """Live status updates refresh interval."""
     hass = MagicMock()
     hass.loop = asyncio.get_running_loop()
-    coord = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+    coord = KippyMapDataUpdateCoordinator(make_context(hass), 1)
     coord._process_data({"operating_status": OPERATING_STATUS.LIVE})
     assert coord.update_interval == timedelta(seconds=coord.live_refresh)
 
@@ -158,7 +166,7 @@ async def test_activity_coordinator_update_and_refresh() -> None:
 
     with patch("homeassistant.util.dt.now", return_value=fake_now):
         coord = KippyActivityCategoriesDataUpdateCoordinator(
-            hass, MagicMock(), api, [1]
+            make_context(hass, api), [1]
         )
         assert coord.update_interval is None
         data = await coord._async_update_data()
@@ -196,8 +204,8 @@ def test_has_config_entry_branches(monkeypatch) -> None:
     hass.loop = loop
     api = MagicMock()
     KippyDataUpdateCoordinator(hass, MagicMock(), api)
-    KippyMapDataUpdateCoordinator(hass, MagicMock(), api, 1)
-    KippyActivityCategoriesDataUpdateCoordinator(hass, MagicMock(), api, [])
+    KippyMapDataUpdateCoordinator(make_context(hass, api), 1)
+    KippyActivityCategoriesDataUpdateCoordinator(make_context(hass, api), [])
     assert all("config_entry" in c for c in calls)
 
 
@@ -223,7 +231,9 @@ async def test_activity_refresh_timer_triggers_refreshes() -> None:
     with patch(
         "custom_components.kippy.coordinator.async_track_point_in_utc_time", fake_track
     ):
-        ActivityRefreshTimer(hass, base, map_coord, activity_coord, 1, 2)
+        ActivityRefreshTimer(
+            ActivityRefreshContext(hass, base, map_coord, activity_coord), 1, 2
+        )
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
@@ -256,6 +266,8 @@ def test_activity_refresh_timer_clamps_to_future() -> None:
             fake_track,
         ),
     ):
-        ActivityRefreshTimer(hass, base, map_coord, activity_coord, 1, 5)
+        ActivityRefreshTimer(
+            ActivityRefreshContext(hass, base, map_coord, activity_coord), 1, 5
+        )
 
     assert scheduled["when"] == now + timedelta(minutes=5)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.kippy import helpers as helpers_module
 from custom_components.kippy.const import DOMAIN
 from custom_components.kippy.helpers import (
     MAP_REFRESH_IDLE_KEY,
@@ -14,7 +15,6 @@ from custom_components.kippy.helpers import (
     normalize_kippy_identifier,
     update_pet_data,
 )
-from custom_components.kippy import helpers as helpers_module
 
 
 def test_build_device_info_with_ids() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,16 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.kippy.const import DOMAIN
-from custom_components.kippy.helpers import build_device_info
+from custom_components.kippy.helpers import (
+    MapRefreshSettings,
+    async_update_map_refresh_settings,
+    build_device_info,
+    get_map_refresh_settings,
+    normalize_kippy_identifier,
+)
 
 
 def test_build_device_info_with_ids() -> None:
@@ -28,3 +39,66 @@ def test_build_device_info_without_ids() -> None:
     info = build_device_info(2, pet, "Name")
     assert info.get("connections") is None
     assert info.get("model") is None
+
+
+def test_normalize_kippy_identifier_falls_back_to_pet_id() -> None:
+    """Pet ID should be used when explicit Kippy IDs are missing."""
+
+    assert normalize_kippy_identifier({"petID": "42"}, include_pet_id=True) == 42
+
+
+def test_normalize_kippy_identifier_invalid_values() -> None:
+    """Non-numeric identifiers should be ignored."""
+
+    assert normalize_kippy_identifier({"kippyID": "abc"}) is None
+    assert normalize_kippy_identifier({"petID": "7"}) is None
+
+
+def test_get_map_refresh_settings_missing() -> None:
+    """None is returned when there are no stored map refresh options."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    assert get_map_refresh_settings(entry, 1) is None
+
+
+def test_get_map_refresh_settings_parses_values() -> None:
+    """Stored map refresh settings are converted to integers."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={
+            "map_refresh_settings": {"1": {"idle_seconds": "480", "live_seconds": 15}}
+        },
+    )
+    settings = get_map_refresh_settings(entry, 1)
+    assert isinstance(settings, MapRefreshSettings)
+    assert settings.idle_seconds == 480
+    assert settings.live_seconds == 15
+
+
+@pytest.mark.asyncio
+async def test_async_update_map_refresh_settings_updates_entry() -> None:
+    """Persisting map refresh settings updates the config entry options."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="1", options={})
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = AsyncMock()
+
+    await async_update_map_refresh_settings(hass, entry, 2, idle_seconds=600)
+
+    hass.config_entries.async_update_entry.assert_awaited_once()
+    call = hass.config_entries.async_update_entry.await_args
+    assert call.args == (entry,)
+    options = call.kwargs["options"]
+    assert options["map_refresh_settings"]["2"]["idle_seconds"] == 600
+
+    # Subsequent calls with unchanged values should avoid extra updates.
+    hass.config_entries.async_update_entry.reset_mock()
+    entry_with_options = MockConfigEntry(
+        domain=DOMAIN, data={}, entry_id="2", options=options
+    )
+    await async_update_map_refresh_settings(
+        hass, entry_with_options, 2, idle_seconds=600
+    )
+    hass.config_entries.async_update_entry.assert_not_awaited()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -187,9 +187,7 @@ async def test_async_setup_entry_uses_stored_map_refresh_settings(
         data={CONF_EMAIL: "a", CONF_PASSWORD: "b"},
         entry_id="1",
         options={
-            "map_refresh_settings": {
-                "1": {"idle_seconds": "480", "live_seconds": "12"}
-            }
+            "map_refresh_settings": {"1": {"idle_seconds": "480", "live_seconds": "12"}}
         },
     )
     entry.add_to_hass(hass)
@@ -220,12 +218,8 @@ async def test_async_setup_entry_uses_stored_map_refresh_settings(
             "custom_components.kippy.KippyActivityCategoriesDataUpdateCoordinator",
             return_value=activity_coord,
         ),
-        patch(
-            "custom_components.kippy.ActivityRefreshTimer", return_value=timer
-        ),
-        patch.object(
-            hass.config_entries, "async_forward_entry_setups", AsyncMock()
-        ),
+        patch("custom_components.kippy.ActivityRefreshTimer", return_value=timer),
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()),
     ):
         result = await async_setup_entry(hass, entry)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,6 +8,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.kippy import async_setup_entry, async_unload_entry
 from custom_components.kippy.const import DOMAIN, PLATFORMS
+from custom_components.kippy.coordinator import (
+    ActivityRefreshContext,
+    CoordinatorContext,
+)
 
 
 @pytest.mark.asyncio
@@ -72,11 +76,11 @@ async def test_async_setup_entry_success_and_unload(hass: HomeAssistant) -> None
         patch(
             "custom_components.kippy.KippyMapDataUpdateCoordinator",
             return_value=map_coord,
-        ),
+        ) as map_cls,
         patch(
             "custom_components.kippy.KippyActivityCategoriesDataUpdateCoordinator",
             return_value=activity_coord,
-        ),
+        ) as act_cls,
         patch(
             "custom_components.kippy.ActivityRefreshTimer", return_value=timer
         ) as timer_cls,
@@ -86,10 +90,26 @@ async def test_async_setup_entry_success_and_unload(hass: HomeAssistant) -> None
         result = await async_setup_entry(hass, entry)
         assert result is True
         assert DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]
+        (map_context, map_pet_id), map_kwargs = map_cls.call_args
+        assert isinstance(map_context, CoordinatorContext)
+        assert map_context.hass is hass
+        assert map_context.api is api
+        assert map_context.config_entry is entry
+        assert map_pet_id == 1
+        assert map_kwargs == {"settings": None}
+        (activity_context, pet_ids), _ = act_cls.call_args
+        assert activity_context is map_context
+        assert pet_ids == [1]
+        (timer_context, timer_pet_id), _ = timer_cls.call_args
+        assert isinstance(timer_context, ActivityRefreshContext)
+        assert timer_context.hass is hass
+        assert timer_context.base is data_coord
+        assert timer_context.map is map_coord
+        assert timer_context.activity is activity_coord
+        assert timer_pet_id == 1
         await async_unload_entry(hass, entry)
         unload.assert_awaited_with(entry, PLATFORMS)
         timer.async_cancel.assert_called_once()
-        timer_cls.assert_called_once()
         assert entry.entry_id not in hass.data.get(DOMAIN, {})
 
 
@@ -141,6 +161,77 @@ async def test_async_setup_entry_handles_expired_pet(hass: HomeAssistant) -> Non
         result = await async_setup_entry(hass, entry)
 
     assert result is True
-    map_cls.assert_called_once_with(hass, entry, api, 1)
-    act_cls.assert_called_once_with(hass, entry, api, [1])
-    timer_cls.assert_called_once()
+    (map_context, map_pet_id), map_kwargs = map_cls.call_args
+    assert isinstance(map_context, CoordinatorContext)
+    assert map_context.hass is hass
+    assert map_context.api is api
+    assert map_pet_id == 1
+    assert map_kwargs == {"settings": None}
+    (activity_context, pet_ids), _ = act_cls.call_args
+    assert activity_context is map_context
+    assert pet_ids == [1]
+    (timer_context, timer_pet_id), _ = timer_cls.call_args
+    assert isinstance(timer_context, ActivityRefreshContext)
+    assert timer_context.map is map_coord
+    assert timer_pet_id == 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_uses_stored_map_refresh_settings(
+    hass: HomeAssistant,
+) -> None:
+    """Stored map refresh options are forwarded when building coordinators."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_EMAIL: "a", CONF_PASSWORD: "b"},
+        entry_id="1",
+        options={
+            "map_refresh_settings": {
+                "1": {"idle_seconds": "480", "live_seconds": "12"}
+            }
+        },
+    )
+    entry.add_to_hass(hass)
+
+    api = AsyncMock()
+    api.login = AsyncMock()
+    data_coord = AsyncMock()
+    data_coord.async_config_entry_first_refresh = AsyncMock()
+    data_coord.data = {"pets": [{"petID": 1, "kippyID": 1}]}
+    map_coord = AsyncMock()
+    map_coord.async_config_entry_first_refresh = AsyncMock()
+    activity_coord = AsyncMock()
+    activity_coord.async_config_entry_first_refresh = AsyncMock()
+    timer = MagicMock()
+
+    with (
+        patch("custom_components.kippy.aiohttp_client.async_get_clientsession"),
+        patch("custom_components.kippy.KippyApi.async_create", return_value=api),
+        patch(
+            "custom_components.kippy.KippyDataUpdateCoordinator",
+            return_value=data_coord,
+        ),
+        patch(
+            "custom_components.kippy.KippyMapDataUpdateCoordinator",
+            return_value=map_coord,
+        ) as map_cls,
+        patch(
+            "custom_components.kippy.KippyActivityCategoriesDataUpdateCoordinator",
+            return_value=activity_coord,
+        ),
+        patch(
+            "custom_components.kippy.ActivityRefreshTimer", return_value=timer
+        ),
+        patch.object(
+            hass.config_entries, "async_forward_entry_setups", AsyncMock()
+        ),
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    (_, pet_id), kwargs = map_cls.call_args
+    assert pet_id == 1
+    settings = kwargs["settings"]
+    assert settings.idle_seconds == 480
+    assert settings.live_seconds == 12

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -276,3 +276,30 @@ async def test_number_async_setup_entry_expired_pet() -> None:
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)
     async_add_entities.assert_called_once_with([])
+
+
+def test_numbers_raise_for_sync_setters() -> None:
+    """Synchronous setters on number entities are unsupported."""
+
+    coordinator = MagicMock()
+    coordinator.data = {"pets": []}
+    coordinator.async_add_listener = MagicMock()
+    gps_number = KippyUpdateFrequencyNumber(coordinator, {"petID": 1})
+    with pytest.raises(NotImplementedError):
+        gps_number.set_native_value(1)
+
+    map_coordinator = MagicMock()
+    map_coordinator.async_add_listener = MagicMock()
+    idle_number = KippyIdleUpdateFrequencyNumber(map_coordinator, {"petID": 2})
+    with pytest.raises(NotImplementedError):
+        idle_number.set_native_value(1)
+
+    live_number = KippyLiveUpdateFrequencyNumber(map_coordinator, {"petID": 3})
+    with pytest.raises(NotImplementedError):
+        live_number.set_native_value(1)
+
+    timer = MagicMock()
+    timer.delay_minutes = 0
+    activity_number = KippyActivityRefreshDelayNumber(timer, {"petID": 4})
+    with pytest.raises(NotImplementedError):
+        activity_number.set_native_value(1)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -85,6 +85,18 @@ async def test_expired_days_sensor_uses_configured_unit() -> None:
     assert sensor.native_value == expected
 
 
+def test_expired_days_sensor_invalid_unit_of_measurement() -> None:
+    """Invalid expired day values result in no native unit."""
+
+    pet = {"petID": "1", "expired_days": "n/a"}
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock()
+    sensor = KippyExpiredDaysSensor(coordinator, pet)
+
+    assert sensor.native_unit_of_measurement is None
+
+
 @pytest.mark.asyncio
 async def test_pet_type_sensor_maps_kind_to_type() -> None:
     """Pet type sensor should map kind code to type label."""
@@ -164,6 +176,240 @@ async def test_run_sensor_uses_configured_unit() -> None:
     assert sensor.native_unit_of_measurement == UnitOfTime.HOURS
     assert sensor.native_value == expected
     assert sensor.suggested_unit_of_measurement == UnitOfTime.HOURS
+
+
+def test_map_sensor_get_datetime_invalid() -> None:
+    """Map-based sensors gracefully handle missing timestamps."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    coordinator.data = None
+    sensor = KippyLastContactSensor(coordinator, {"petID": 1})
+    assert sensor.native_value is None
+
+    coordinator.data = {"contact_time": "invalid"}
+    assert sensor.native_value is None
+
+
+def test_home_distance_sensor_handles_missing_coordinates(monkeypatch) -> None:
+    """Distance sensor returns None for incomplete or invalid data."""
+
+    hass = MagicMock()
+    hass.config.units.length_unit = UnitOfLength.KILOMETERS
+    hass.config.latitude = 0
+    hass.config.longitude = 0
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyHomeDistanceSensor(coordinator, {"petID": 1})
+    sensor.hass = hass
+
+    coordinator.data = None
+    assert sensor.native_value is None
+
+    coordinator.data = {"gps_latitude": None, "gps_longitude": 0}
+    assert sensor.native_value is None
+
+    coordinator.data = {"gps_latitude": "a", "gps_longitude": "b"}
+    assert sensor.native_value is None
+
+    monkeypatch.setattr(
+        "custom_components.kippy.sensor.location_distance", lambda *args, **kwargs: None
+    )
+    coordinator.data = {"gps_latitude": 0, "gps_longitude": 0}
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_extra_state_none_without_data() -> None:
+    """Activity sensor exposes no extra attributes until data is processed."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    coordinator.get_activities.return_value = []
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.extra_state_attributes is None
+
+
+def test_activity_sensor_returns_none_when_value_missing() -> None:
+    """Missing values result in None native state."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    coordinator.get_activities.return_value = [{"date": today, "run": None}]
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_grouped_activities_filters_nonmatching() -> None:
+    """Grouped activities sum values for the current day only."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    today = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    activities = [
+        {"activity": "walk", "data": []},
+        {
+            "activity": "run",
+            "data": [
+                {"timeCaption": "20230101", "valueMinutes": 2},
+                {
+                    "timeCaption": today.strftime("%Y%m%d") + "T1200",
+                    "valueMinutes": 5,
+                },
+                {
+                    "timeCaption": today.strftime("%Y%m%d") + "T1300",
+                    "minutes": 3,
+                },
+            ],
+        },
+    ]
+
+    total, date_str = sensor._value_from_grouped_activities(activities, today)
+    assert total == 8.0
+    assert date_str == "2024-01-02"
+
+
+def test_activity_sensor_grouped_activities_no_match_returns_none() -> None:
+    """Grouped data without the metric returns no value."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    activities = [{"activity": "walk", "data": []}]
+
+    total, date_str = sensor._value_from_grouped_activities(
+        activities, datetime.now(timezone.utc)
+    )
+    assert total is None and date_str is None
+
+
+def test_activity_sensor_daily_entries_nested_list() -> None:
+    """Daily entries handle nested activity lists and dictionaries."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    activities = [
+        {"date": "1999-01-01", "run": 5},
+        {
+            "date": today,
+            "run": None,
+            "activities": [
+                {"name": "run", "value": {"minutes": 7}},
+            ],
+        },
+    ]
+
+    value, date_str = sensor._value_from_daily_entries(
+        activities, datetime.now(timezone.utc)
+    )
+    assert value == 7
+    assert date_str == today
+
+
+def test_activity_sensor_daily_entries_no_match_returns_none() -> None:
+    """Daily entries return None when no data matches today."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    activities = [{"date": "1999-01-01", "run": 5}]
+    value, date_str = sensor._value_from_daily_entries(
+        activities, datetime.now(timezone.utc)
+    )
+    assert value is None and date_str is None
+
+
+def test_activity_sensor_extract_helpers() -> None:
+    """Helper methods extract dates and first-present values."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor._extract_date({"foo": "bar"}) is None
+    assert sensor._extract_first_present({"count": 3}, ("value", "count")) == 3
+
+
+def test_activity_sensor_activity_list_missing_metric_returns_none() -> None:
+    """Activity lists without the metric return None."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    assert sensor._value_from_activity_list([{"name": "walk"}]) is None
+
+
+def test_activity_sensor_extract_first_present_returns_none() -> None:
+    """Missing keys result in None for first-present extraction."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    assert sensor._extract_first_present({}, ("value", "count")) is None
+
+
+def test_activity_sensor_extract_numeric_invalid() -> None:
+    """Invalid numeric values are ignored."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    data = {"value": "bad", "count": "also bad"}
+    assert sensor._extract_numeric_value(data, ("value", "count")) is None
+
+
+def test_activity_sensor_convert_invalid_value() -> None:
+    """Non-numeric activity values are ignored."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyStepsSensor(coordinator, {"petID": 1})
+    assert sensor._convert_activity_value("invalid") is None
+
+
+def test_activity_sensor_native_value_grouped_missing_metric() -> None:
+    """Grouped activity payloads without the metric return ``None``."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    coordinator.get_activities = MagicMock(
+        return_value=[{"activity": "walk", "data": []}]
+    )
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_native_value_daily_missing_metric() -> None:
+    """Daily entries without metric data also return ``None``."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    coordinator.get_activities = MagicMock(
+        return_value=[{"date": today, "activities": [{"name": "walk"}]}]
+    )
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_native_value_daily_missing_keys() -> None:
+    """Daily entries with empty dictionaries return ``None`` after extraction."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    coordinator.get_activities = MagicMock(return_value=[{"date": today, "run": {}}])
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -462,3 +462,61 @@ def test_live_and_ignore_lbs_device_info() -> None:
     ignore = KippyIgnoreLBSSwitch(map_coord, pet)
     assert live.device_info["name"] == "Kippy Rex"
     assert ignore.device_info["name"] == "Kippy Rex"
+
+
+def test_energy_saving_switch_handle_map_update_no_data() -> None:
+    """Map updates without data are ignored."""
+
+    pet = {"petID": 1, "energySavingMode": 0}
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+    coordinator.async_set_updated_data = MagicMock()
+    map_coord = MagicMock()
+    map_coord.data = {}
+    map_coord.async_add_listener = MagicMock(return_value=MagicMock())
+    switch = KippyEnergySavingSwitch(coordinator, pet, map_coord)
+    switch.async_write_ha_state = MagicMock()
+
+    switch._handle_map_update()
+
+    switch.async_write_ha_state.assert_not_called()
+    coordinator.async_set_updated_data.assert_not_called()
+
+
+def test_switches_raise_for_sync_methods() -> None:
+    """Synchronous switch methods are not supported."""
+
+    pet = {"petID": 1}
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+    gps = KippyGpsDefaultSwitch(coordinator, pet.copy())
+    with pytest.raises(NotImplementedError):
+        gps.turn_on()
+    with pytest.raises(NotImplementedError):
+        gps.turn_off()
+
+    map_coord = MagicMock()
+    map_coord.async_add_listener = MagicMock(return_value=MagicMock())
+    energy = KippyEnergySavingSwitch(coordinator, pet.copy(), map_coord)
+    with pytest.raises(NotImplementedError):
+        energy.turn_on()
+    with pytest.raises(NotImplementedError):
+        energy.turn_off()
+
+    map_coord2 = MagicMock()
+    map_coord2.data = {}
+    map_coord2.async_add_listener = MagicMock(return_value=MagicMock())
+    live = KippyLiveTrackingSwitch(map_coord2, pet.copy())
+    with pytest.raises(NotImplementedError):
+        live.turn_on()
+    with pytest.raises(NotImplementedError):
+        live.turn_off()
+
+    ignore = KippyIgnoreLBSSwitch(map_coord2, pet.copy())
+    with pytest.raises(NotImplementedError):
+        ignore.turn_on()
+    with pytest.raises(NotImplementedError):
+        ignore.turn_off()


### PR DESCRIPTION
## Summary
- persist stored idle/live map refresh values in config entry options and load them when coordinators are built
- update the idle/live number entities to write their values back into the config entry so preferences survive restarts
- extend helper, init, and number tests to cover the new persistence behaviour
- clarify `AGENTS.md` linting guidance so pylint runs without duplicate commands

## Testing
- pylint custom_components/kippy
- pytest --disable-warnings -q

------
https://chatgpt.com/codex/tasks/task_e_68cfdc5aaaf88326a3b6c827a56f8170