### PR TITLE
Merge branch 'actions' into work

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile = black
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -916,11 +916,9 @@ rules:
 
 ### Code Quality & Linting
 
-- **Required before submission**: `pylint custom_components/kippy`
+- **Required before submission**: Run `pylint custom_components/kippy` to lint the entire integration
 - **Run all linters on all files**: `pre-commit run --all-files`
 - **Run linters on staged files only**: `pre-commit run`
-- **PyLint on everything** (slow): `pylint custom_components`
-- **PyLint on specific folder**: `pylint custom_components/kippy`
 - **MyPy type checking (whole project)**: `mypy custom_components/`
 - **MyPy on specific integration**: `mypy custom_components/kippy`
 

--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -20,6 +20,7 @@ from .coordinator import (
 )
 from .helpers import (
     API_EXCEPTIONS,
+    get_map_refresh_settings,
     is_pet_subscription_active,
     normalize_kippy_identifier,
 )
@@ -95,7 +96,10 @@ async def _async_build_map_coordinators(
         kippy_id = normalize_kippy_identifier(pet, include_pet_id=True)
         if kippy_id is None:
             continue
-        map_coordinator = KippyMapDataUpdateCoordinator(context, kippy_id)
+        settings = get_map_refresh_settings(context.config_entry, pet_id)
+        map_coordinator = KippyMapDataUpdateCoordinator(
+            context, kippy_id, settings=settings
+        )
         await map_coordinator.async_config_entry_first_refresh()
         map_coordinators[pet_id] = map_coordinator
         active_pet_ids.append(pet_id)

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -22,7 +22,7 @@ from .const import (
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
 )
-from .helpers import API_EXCEPTIONS
+from .helpers import API_EXCEPTIONS, MapRefreshSettings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,14 +38,6 @@ class CoordinatorContext:
     hass: HomeAssistant
     config_entry: ConfigEntry
     api: KippyApi
-
-
-@dataclass(slots=True)
-class MapRefreshSettings:
-    """Refresh intervals for map updates in seconds."""
-
-    idle_seconds: int = 300
-    live_seconds: int = 10
 
 
 class KippyDataUpdateCoordinator(DataUpdateCoordinator):

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -18,6 +18,7 @@ from .coordinator import (
 )
 from .entity import KippyMapEntity, KippyPetEntity
 from .helpers import (
+    async_update_map_refresh_settings,
     build_device_info,
     is_pet_subscription_active,
     normalize_kippy_identifier,
@@ -127,7 +128,11 @@ class KippyIdleUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
         return float(self.coordinator.idle_refresh) / 60
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.async_set_idle_refresh(int(value * 60))
+        seconds = int(value * 60)
+        await self.coordinator.async_set_idle_refresh(seconds)
+        await async_update_map_refresh_settings(
+            self.hass, self.coordinator.config_entry, self._pet_id, idle_seconds=seconds
+        )
         self.async_write_ha_state()
 
     def set_native_value(self, value: float) -> None:
@@ -160,7 +165,11 @@ class KippyLiveUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
         return float(self.coordinator.live_refresh)
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.async_set_live_refresh(int(value))
+        seconds = int(value)
+        await self.coordinator.async_set_live_refresh(seconds)
+        await async_update_map_refresh_settings(
+            self.hass, self.coordinator.config_entry, self._pet_id, live_seconds=seconds
+        )
         self.async_write_ha_state()
 
     def set_native_value(self, value: float) -> None:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ pytest-homeassistant-custom-component==0.13.278
 aiohttp==3.12.15
 go2rtc-client==0.2.1
 PyTurboJPEG==1.8.0
+isort==5.13.2
 pre-commit==4.3.0
 python-dotenv==1.1.1
 pylint==3.3.8

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -195,3 +195,24 @@ def test_button_device_info_properties() -> None:
     activity = KippyActivityCategoriesButton(coordinator, pet)
     info2 = activity.device_info
     assert info2["name"] == "Kippy Rex"
+
+
+def test_buttons_raise_for_sync_press() -> None:
+    """Synchronous press methods are intentionally unsupported."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    map_button = KippyRefreshMapAttributesButton(coordinator, {"petID": 1})
+    with pytest.raises(NotImplementedError):
+        map_button.press()
+
+    activity_button = KippyActivityCategoriesButton(MagicMock(), {"petID": 2})
+    with pytest.raises(NotImplementedError):
+        activity_button.press()
+
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "1"
+    pets_button = KippyRefreshPetsButton(hass, entry)
+    with pytest.raises(NotImplementedError):
+        pets_button.press()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientError, ClientResponseError
+from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
 from custom_components.kippy.config_flow import KippyConfigFlow
@@ -36,6 +37,7 @@ async def test_config_flow_success() -> None:
             "cannot_connect",
         ),
         (ClientError(), "cannot_connect"),
+        (RuntimeError(), "unknown"),
         (Exception(), "unknown"),
     ],
 )
@@ -55,3 +57,15 @@ async def test_config_flow_errors(error: Exception, base: str) -> None:
         result = await flow.async_step_user({CONF_EMAIL: "user", CONF_PASSWORD: "pass"})
     assert result["type"].value == "form"
     assert result["errors"]["base"] == base
+
+
+def test_config_flow_is_matching() -> None:
+    """The flow matches other Kippy flows but not arbitrary ones."""
+
+    flow = KippyConfigFlow()
+    assert flow.is_matching(KippyConfigFlow())
+
+    class DummyFlow(config_entries.ConfigFlow):
+        pass
+
+    assert not flow.is_matching(DummyFlow())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,19 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.kippy import helpers as helpers_module
 from custom_components.kippy.const import DOMAIN
 from custom_components.kippy.helpers import (
+    MAP_REFRESH_IDLE_KEY,
+    MAP_REFRESH_LIVE_KEY,
+    MapRefreshSettings,
+    async_update_map_refresh_settings,
     build_device_info,
+    get_map_refresh_settings,
     normalize_kippy_identifier,
+    update_pet_data,
 )
 
 
@@ -44,3 +56,130 @@ def test_normalize_kippy_identifier_invalid_values() -> None:
 
     assert normalize_kippy_identifier({"kippyID": "abc"}) is None
     assert normalize_kippy_identifier({"petID": "7"}) is None
+
+
+def test_get_map_refresh_settings_missing() -> None:
+    """None is returned when there are no stored map refresh options."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    assert get_map_refresh_settings(entry, 1) is None
+
+
+def test_get_map_refresh_settings_parses_values() -> None:
+    """Stored map refresh settings are converted to integers."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={
+            "map_refresh_settings": {"1": {"idle_seconds": "480", "live_seconds": 15}}
+        },
+    )
+    settings = get_map_refresh_settings(entry, 1)
+    assert isinstance(settings, MapRefreshSettings)
+    assert settings.idle_seconds == 480
+    assert settings.live_seconds == 15
+
+
+@pytest.mark.asyncio
+async def test_async_update_map_refresh_settings_updates_entry() -> None:
+    """Persisting map refresh settings updates the config entry options."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="1", options={})
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = AsyncMock()
+
+    await async_update_map_refresh_settings(hass, entry, 2, idle_seconds=600)
+
+    hass.config_entries.async_update_entry.assert_awaited_once()
+    call = hass.config_entries.async_update_entry.await_args
+    assert call.args == (entry,)
+    options = call.kwargs["options"]
+    assert options["map_refresh_settings"]["2"]["idle_seconds"] == 600
+
+    # Subsequent calls with unchanged values should avoid extra updates.
+    hass.config_entries.async_update_entry.reset_mock()
+    entry_with_options = MockConfigEntry(
+        domain=DOMAIN, data={}, entry_id="2", options=options
+    )
+    await async_update_map_refresh_settings(
+        hass, entry_with_options, 2, idle_seconds=600
+    )
+    hass.config_entries.async_update_entry.assert_not_awaited()
+
+
+def test_update_pet_data_preserves_and_returns_current() -> None:
+    """update_pet_data preserves requested fields and returns current when missing."""
+
+    pets = [
+        {"petID": 1, "value": 1},
+        {"petID": 2, "value": 2},
+    ]
+    current = {"petID": 2, "value": 3, "keep": True}
+    updated = update_pet_data(pets, 2, current, preserve=("keep",))
+    assert updated["value"] == 2
+    assert updated["keep"] is True
+    missing = update_pet_data(pets, 3, current)
+    assert missing is current
+
+
+def test_normalize_refresh_value_invalid_inputs() -> None:
+    """_normalize_refresh_value handles invalid data."""
+
+    assert helpers_module._normalize_refresh_value("bad") is None
+    assert helpers_module._normalize_refresh_value(0) is None
+
+
+def test_get_map_refresh_settings_invalid_mapping() -> None:
+    """Invalid stored structures result in None settings."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"map_refresh_settings": {"1": "invalid"}},
+    )
+    assert get_map_refresh_settings(entry, 1) is None
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={
+            "map_refresh_settings": {
+                "1": {"idle_seconds": "-10", "live_seconds": "bad"}
+            }
+        },
+    )
+    assert get_map_refresh_settings(entry, 1) is None
+
+
+def test_collect_refresh_updates_filters_invalid_values() -> None:
+    """Only normalized refresh values are returned in updates."""
+
+    updates = helpers_module._collect_refresh_updates(5, "bad")
+    assert updates == {MAP_REFRESH_IDLE_KEY: 5}
+    assert MAP_REFRESH_LIVE_KEY not in updates
+    assert helpers_module._collect_refresh_updates(None, None) == {}
+    assert helpers_module._collect_refresh_updates(None, 8) == {MAP_REFRESH_LIVE_KEY: 8}
+
+
+def test_collect_refresh_updates_accepts_string_values() -> None:
+    """String inputs are normalized for both idle and live refresh updates."""
+
+    updates = helpers_module._collect_refresh_updates("15", "20")
+    assert updates == {
+        MAP_REFRESH_IDLE_KEY: 15,
+        MAP_REFRESH_LIVE_KEY: 20,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_update_map_refresh_settings_no_updates() -> None:
+    """Calling update without values exits early."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="3", options={})
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = AsyncMock()
+
+    await async_update_map_refresh_settings(hass, entry, 4)
+
+    hass.config_entries.async_update_entry.assert_not_awaited()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -90,12 +90,13 @@ async def test_async_setup_entry_success_and_unload(hass: HomeAssistant) -> None
         result = await async_setup_entry(hass, entry)
         assert result is True
         assert DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]
-        (map_context, map_pet_id), _ = map_cls.call_args
+        (map_context, map_pet_id), map_kwargs = map_cls.call_args
         assert isinstance(map_context, CoordinatorContext)
         assert map_context.hass is hass
         assert map_context.api is api
         assert map_context.config_entry is entry
         assert map_pet_id == 1
+        assert map_kwargs == {"settings": None}
         (activity_context, pet_ids), _ = act_cls.call_args
         assert activity_context is map_context
         assert pet_ids == [1]
@@ -160,11 +161,12 @@ async def test_async_setup_entry_handles_expired_pet(hass: HomeAssistant) -> Non
         result = await async_setup_entry(hass, entry)
 
     assert result is True
-    (map_context, map_pet_id), _ = map_cls.call_args
+    (map_context, map_pet_id), map_kwargs = map_cls.call_args
     assert isinstance(map_context, CoordinatorContext)
     assert map_context.hass is hass
     assert map_context.api is api
     assert map_pet_id == 1
+    assert map_kwargs == {"settings": None}
     (activity_context, pet_ids), _ = act_cls.call_args
     assert activity_context is map_context
     assert pet_ids == [1]
@@ -172,3 +174,58 @@ async def test_async_setup_entry_handles_expired_pet(hass: HomeAssistant) -> Non
     assert isinstance(timer_context, ActivityRefreshContext)
     assert timer_context.map is map_coord
     assert timer_pet_id == 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_uses_stored_map_refresh_settings(
+    hass: HomeAssistant,
+) -> None:
+    """Stored map refresh options are forwarded when building coordinators."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_EMAIL: "a", CONF_PASSWORD: "b"},
+        entry_id="1",
+        options={
+            "map_refresh_settings": {"1": {"idle_seconds": "480", "live_seconds": "12"}}
+        },
+    )
+    entry.add_to_hass(hass)
+
+    api = AsyncMock()
+    api.login = AsyncMock()
+    data_coord = AsyncMock()
+    data_coord.async_config_entry_first_refresh = AsyncMock()
+    data_coord.data = {"pets": [{"petID": 1, "kippyID": 1}]}
+    map_coord = AsyncMock()
+    map_coord.async_config_entry_first_refresh = AsyncMock()
+    activity_coord = AsyncMock()
+    activity_coord.async_config_entry_first_refresh = AsyncMock()
+    timer = MagicMock()
+
+    with (
+        patch("custom_components.kippy.aiohttp_client.async_get_clientsession"),
+        patch("custom_components.kippy.KippyApi.async_create", return_value=api),
+        patch(
+            "custom_components.kippy.KippyDataUpdateCoordinator",
+            return_value=data_coord,
+        ),
+        patch(
+            "custom_components.kippy.KippyMapDataUpdateCoordinator",
+            return_value=map_coord,
+        ) as map_cls,
+        patch(
+            "custom_components.kippy.KippyActivityCategoriesDataUpdateCoordinator",
+            return_value=activity_coord,
+        ),
+        patch("custom_components.kippy.ActivityRefreshTimer", return_value=timer),
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()),
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    (_, pet_id), kwargs = map_cls.call_args
+    assert pet_id == 1
+    settings = kwargs["settings"]
+    assert settings.idle_seconds == 480
+    assert settings.live_seconds == 12

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -130,6 +130,7 @@ async def test_idle_and_live_numbers() -> None:
     map_coordinator.async_set_idle_refresh = AsyncMock()
     map_coordinator.async_set_live_refresh = AsyncMock()
     map_coordinator.async_add_listener = MagicMock()
+    map_coordinator.config_entry = MagicMock()
 
     idle = KippyIdleUpdateFrequencyNumber(map_coordinator, pet)
     live = KippyLiveUpdateFrequencyNumber(map_coordinator, pet)
@@ -137,10 +138,24 @@ async def test_idle_and_live_numbers() -> None:
     assert live.native_value == 10.0
     idle.async_write_ha_state = MagicMock()
     live.async_write_ha_state = MagicMock()
-    await idle.async_set_native_value(6)
-    await live.async_set_native_value(7)
+    hass = MagicMock()
+    idle.hass = hass
+    live.hass = hass
+    with patch(
+        "custom_components.kippy.number.async_update_map_refresh_settings",
+        AsyncMock(),
+    ) as update_options:
+        await idle.async_set_native_value(6)
+        await live.async_set_native_value(7)
     map_coordinator.async_set_idle_refresh.assert_called_once_with(360)
     map_coordinator.async_set_live_refresh.assert_called_once_with(7)
+    assert update_options.await_count == 2
+    idle_call = update_options.await_args_list[0]
+    assert idle_call.args == (hass, map_coordinator.config_entry, 1)
+    assert idle_call.kwargs == {"idle_seconds": 360}
+    live_call = update_options.await_args_list[1]
+    assert live_call.args == (hass, map_coordinator.config_entry, 1)
+    assert live_call.kwargs == {"live_seconds": 7}
     idle.async_write_ha_state.assert_called_once()
     live.async_write_ha_state.assert_called_once()
     idle_info = idle.device_info
@@ -261,3 +276,30 @@ async def test_number_async_setup_entry_expired_pet() -> None:
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)
     async_add_entities.assert_called_once_with([])
+
+
+def test_numbers_raise_for_sync_setters() -> None:
+    """Synchronous setters on number entities are unsupported."""
+
+    coordinator = MagicMock()
+    coordinator.data = {"pets": []}
+    coordinator.async_add_listener = MagicMock()
+    gps_number = KippyUpdateFrequencyNumber(coordinator, {"petID": 1})
+    with pytest.raises(NotImplementedError):
+        gps_number.set_native_value(1)
+
+    map_coordinator = MagicMock()
+    map_coordinator.async_add_listener = MagicMock()
+    idle_number = KippyIdleUpdateFrequencyNumber(map_coordinator, {"petID": 2})
+    with pytest.raises(NotImplementedError):
+        idle_number.set_native_value(1)
+
+    live_number = KippyLiveUpdateFrequencyNumber(map_coordinator, {"petID": 3})
+    with pytest.raises(NotImplementedError):
+        live_number.set_native_value(1)
+
+    timer = MagicMock()
+    timer.delay_minutes = 0
+    activity_number = KippyActivityRefreshDelayNumber(timer, {"petID": 4})
+    with pytest.raises(NotImplementedError):
+        activity_number.set_native_value(1)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -85,6 +85,18 @@ async def test_expired_days_sensor_uses_configured_unit() -> None:
     assert sensor.native_value == expected
 
 
+def test_expired_days_sensor_invalid_unit_of_measurement() -> None:
+    """Invalid expired day values result in no native unit."""
+
+    pet = {"petID": "1", "expired_days": "n/a"}
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock()
+    sensor = KippyExpiredDaysSensor(coordinator, pet)
+
+    assert sensor.native_unit_of_measurement is None
+
+
 @pytest.mark.asyncio
 async def test_pet_type_sensor_maps_kind_to_type() -> None:
     """Pet type sensor should map kind code to type label."""
@@ -164,6 +176,240 @@ async def test_run_sensor_uses_configured_unit() -> None:
     assert sensor.native_unit_of_measurement == UnitOfTime.HOURS
     assert sensor.native_value == expected
     assert sensor.suggested_unit_of_measurement == UnitOfTime.HOURS
+
+
+def test_map_sensor_get_datetime_invalid() -> None:
+    """Map-based sensors gracefully handle missing timestamps."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    coordinator.data = None
+    sensor = KippyLastContactSensor(coordinator, {"petID": 1})
+    assert sensor.native_value is None
+
+    coordinator.data = {"contact_time": "invalid"}
+    assert sensor.native_value is None
+
+
+def test_home_distance_sensor_handles_missing_coordinates(monkeypatch) -> None:
+    """Distance sensor returns None for incomplete or invalid data."""
+
+    hass = MagicMock()
+    hass.config.units.length_unit = UnitOfLength.KILOMETERS
+    hass.config.latitude = 0
+    hass.config.longitude = 0
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyHomeDistanceSensor(coordinator, {"petID": 1})
+    sensor.hass = hass
+
+    coordinator.data = None
+    assert sensor.native_value is None
+
+    coordinator.data = {"gps_latitude": None, "gps_longitude": 0}
+    assert sensor.native_value is None
+
+    coordinator.data = {"gps_latitude": "a", "gps_longitude": "b"}
+    assert sensor.native_value is None
+
+    monkeypatch.setattr(
+        "custom_components.kippy.sensor.location_distance", lambda *args, **kwargs: None
+    )
+    coordinator.data = {"gps_latitude": 0, "gps_longitude": 0}
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_extra_state_none_without_data() -> None:
+    """Activity sensor exposes no extra attributes until data is processed."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    coordinator.get_activities.return_value = []
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.extra_state_attributes is None
+
+
+def test_activity_sensor_returns_none_when_value_missing() -> None:
+    """Missing values result in None native state."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    coordinator.get_activities.return_value = [{"date": today, "run": None}]
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_grouped_activities_filters_nonmatching() -> None:
+    """Grouped activities sum values for the current day only."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    today = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    activities = [
+        {"activity": "walk", "data": []},
+        {
+            "activity": "run",
+            "data": [
+                {"timeCaption": "20230101", "valueMinutes": 2},
+                {
+                    "timeCaption": today.strftime("%Y%m%d") + "T1200",
+                    "valueMinutes": 5,
+                },
+                {
+                    "timeCaption": today.strftime("%Y%m%d") + "T1300",
+                    "minutes": 3,
+                },
+            ],
+        },
+    ]
+
+    total, date_str = sensor._value_from_grouped_activities(activities, today)
+    assert total == 8.0
+    assert date_str == "2024-01-02"
+
+
+def test_activity_sensor_grouped_activities_no_match_returns_none() -> None:
+    """Grouped data without the metric returns no value."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    activities = [{"activity": "walk", "data": []}]
+
+    total, date_str = sensor._value_from_grouped_activities(
+        activities, datetime.now(timezone.utc)
+    )
+    assert total is None and date_str is None
+
+
+def test_activity_sensor_daily_entries_nested_list() -> None:
+    """Daily entries handle nested activity lists and dictionaries."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    activities = [
+        {"date": "1999-01-01", "run": 5},
+        {
+            "date": today,
+            "run": None,
+            "activities": [
+                {"name": "run", "value": {"minutes": 7}},
+            ],
+        },
+    ]
+
+    value, date_str = sensor._value_from_daily_entries(
+        activities, datetime.now(timezone.utc)
+    )
+    assert value == 7
+    assert date_str == today
+
+
+def test_activity_sensor_daily_entries_no_match_returns_none() -> None:
+    """Daily entries return None when no data matches today."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    activities = [{"date": "1999-01-01", "run": 5}]
+    value, date_str = sensor._value_from_daily_entries(
+        activities, datetime.now(timezone.utc)
+    )
+    assert value is None and date_str is None
+
+
+def test_activity_sensor_extract_helpers() -> None:
+    """Helper methods extract dates and first-present values."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor._extract_date({"foo": "bar"}) is None
+    assert sensor._extract_first_present({"count": 3}, ("value", "count")) == 3
+
+
+def test_activity_sensor_activity_list_missing_metric_returns_none() -> None:
+    """Activity lists without the metric return None."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    assert sensor._value_from_activity_list([{"name": "walk"}]) is None
+
+
+def test_activity_sensor_extract_first_present_returns_none() -> None:
+    """Missing keys result in None for first-present extraction."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    assert sensor._extract_first_present({}, ("value", "count")) is None
+
+
+def test_activity_sensor_extract_numeric_invalid() -> None:
+    """Invalid numeric values are ignored."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+    data = {"value": "bad", "count": "also bad"}
+    assert sensor._extract_numeric_value(data, ("value", "count")) is None
+
+
+def test_activity_sensor_convert_invalid_value() -> None:
+    """Non-numeric activity values are ignored."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    sensor = KippyStepsSensor(coordinator, {"petID": 1})
+    assert sensor._convert_activity_value("invalid") is None
+
+
+def test_activity_sensor_native_value_grouped_missing_metric() -> None:
+    """Grouped activity payloads without the metric return ``None``."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    coordinator.get_activities = MagicMock(
+        return_value=[{"activity": "walk", "data": []}]
+    )
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_native_value_daily_missing_metric() -> None:
+    """Daily entries without metric data also return ``None``."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    coordinator.get_activities = MagicMock(
+        return_value=[{"date": today, "activities": [{"name": "walk"}]}]
+    )
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
+
+
+def test_activity_sensor_native_value_daily_missing_keys() -> None:
+    """Daily entries with empty dictionaries return ``None`` after extraction."""
+
+    coordinator = MagicMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    coordinator.get_activities = MagicMock(return_value=[{"date": today, "run": {}}])
+    sensor = KippyRunSensor(coordinator, {"petID": 1})
+
+    assert sensor.native_value is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -462,3 +462,61 @@ def test_live_and_ignore_lbs_device_info() -> None:
     ignore = KippyIgnoreLBSSwitch(map_coord, pet)
     assert live.device_info["name"] == "Kippy Rex"
     assert ignore.device_info["name"] == "Kippy Rex"
+
+
+def test_energy_saving_switch_handle_map_update_no_data() -> None:
+    """Map updates without data are ignored."""
+
+    pet = {"petID": 1, "energySavingMode": 0}
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+    coordinator.async_set_updated_data = MagicMock()
+    map_coord = MagicMock()
+    map_coord.data = {}
+    map_coord.async_add_listener = MagicMock(return_value=MagicMock())
+    switch = KippyEnergySavingSwitch(coordinator, pet, map_coord)
+    switch.async_write_ha_state = MagicMock()
+
+    switch._handle_map_update()
+
+    switch.async_write_ha_state.assert_not_called()
+    coordinator.async_set_updated_data.assert_not_called()
+
+
+def test_switches_raise_for_sync_methods() -> None:
+    """Synchronous switch methods are not supported."""
+
+    pet = {"petID": 1}
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+    gps = KippyGpsDefaultSwitch(coordinator, pet.copy())
+    with pytest.raises(NotImplementedError):
+        gps.turn_on()
+    with pytest.raises(NotImplementedError):
+        gps.turn_off()
+
+    map_coord = MagicMock()
+    map_coord.async_add_listener = MagicMock(return_value=MagicMock())
+    energy = KippyEnergySavingSwitch(coordinator, pet.copy(), map_coord)
+    with pytest.raises(NotImplementedError):
+        energy.turn_on()
+    with pytest.raises(NotImplementedError):
+        energy.turn_off()
+
+    map_coord2 = MagicMock()
+    map_coord2.data = {}
+    map_coord2.async_add_listener = MagicMock(return_value=MagicMock())
+    live = KippyLiveTrackingSwitch(map_coord2, pet.copy())
+    with pytest.raises(NotImplementedError):
+        live.turn_on()
+    with pytest.raises(NotImplementedError):
+        live.turn_off()
+
+    ignore = KippyIgnoreLBSSwitch(map_coord2, pet.copy())
+    with pytest.raises(NotImplementedError):
+        ignore.turn_on()
+    with pytest.raises(NotImplementedError):
+        ignore.turn_off()


### PR DESCRIPTION
## Summary
- restore the map refresh helper utilities and persistence logic added on the actions branch
- wire stored map refresh settings into coordinator creation and number entities
- sync the associated helper, init and number tests from the actions branch

## Testing
- python script/hassfest --integration-path custom_components/kippy
- pytest ./tests --cov=custom_components.kippy --cov-report term-missing --durations-min=1 --durations=0 --numprocesses=auto

------
https://chatgpt.com/codex/tasks/task_e_68d01be97c508326bd7444a8d30df5a3