### PR TITLE
Handle async_unload_entry result

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -72,11 +72,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Kippy config entry."""
-    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    data = hass.data[DOMAIN].pop(entry.entry_id)
-    for timer in data.get("activity_timers", {}).values():
-        timer.async_cancel()
-    return True
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        data = hass.data[DOMAIN].pop(entry.entry_id, None)
+        if data is not None:
+            for timer in data.get("activity_timers", {}).values():
+                timer.async_cancel()
+    return unload_ok
 
 
 async def _async_build_map_coordinators(


### PR DESCRIPTION
## Summary
- preserve integration data when unloading platforms fails
- return the unload result so Home Assistant can react appropriately

## Testing
- isort .
- ruff format
- ruff check
- python -m flake8 custom_components/kippy tests
- python -m pylint custom_components/kippy tests
- python script/hassfest --integration-path custom_components/kippy
- pytest ./tests --cov=custom_components.kippy --cov-report term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d153440ec483269e4775dbcb4e46d9