### PR TITLE
Bump integration version to 1.0.2

### DIFF
--- a/custom_components/kippy/manifest.json
+++ b/custom_components/kippy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ThomasHFWright/kippy-homeassistant/issues",
   "requirements": [],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
## Summary
- update the integration manifest to version 1.0.2 for HACS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3be2fbeac83268fadc061f7e9e6e7