### PR TITLE
Handle string operating status values in Kippy map coordinator

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -116,6 +116,11 @@ OPERATING_STATUS_MAP: dict[int, str] = {
     OPERATING_STATUS.ENERGY_SAVING: "energy_saving",
 }
 
+# Mapping of operating status strings back to their numeric codes.
+OPERATING_STATUS_REVERSE_MAP: dict[str, int] = {
+    value: key for key, value in OPERATING_STATUS_MAP.items()
+}
+
 # App action identifiers used by the API.
 APP_ACTION = SimpleNamespace(
     TURN_LIVE_TRACKING_ON=2,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -46,6 +46,28 @@ async def test_process_new_data_maps_operating_status() -> None:
 
 
 @pytest.mark.asyncio
+async def test_process_new_data_accepts_string_operating_status() -> None:
+    """process_new_data should keep string operating status values stable."""
+    hass = MagicMock()
+    hass.loop = asyncio.get_running_loop()
+    coordinator = KippyMapDataUpdateCoordinator(make_context(hass), 1)
+
+    coordinator.process_new_data({"operating_status": "live"})
+
+    assert (
+        coordinator.data["operating_status"]
+        == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
+    )
+
+    coordinator.process_new_data({"operating_status": "IDLE"})
+
+    assert (
+        coordinator.data["operating_status"]
+        == OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]
+    )
+
+
+@pytest.mark.asyncio
 async def test_data_coordinator_update_success() -> None:
     """_async_update_data returns pets list on success."""
     hass = MagicMock()


### PR DESCRIPTION
## Summary
- preserve numeric mappings and add reverse lookup for operating status strings
- normalize operating status updates so live tracking remains active when API returns string values
- extend coordinator tests to cover string operating status inputs

## Testing
- isort .
- ruff format
- ruff check
- python -m flake8 custom_components/kippy tests
- python -m pylint custom_components/kippy tests
- python script/hassfest --integration-path custom_components/kippy
- pytest ./tests --cov=custom_components.kippy --cov-report term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e3c0c8417483269e128de3c653c321