### PR TITLE
Use workspace virtualenv for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,9 +34,10 @@
       // Please keep this file in sync with settings in .vscode/settings.default.json
       "settings": {
         "python.experiments.optOutFrom": ["pythonTestAdapter"],
-        "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
+        "python.testing.cwd": "${containerWorkspaceFolder}",
         "pylint.importStrategy": "fromEnvironment",
-        "pylint.path": ["/home/vscode/.local/ha-venv/bin/pylint"],
+        "pylint.path": ["${containerWorkspaceFolder}/.venv/bin/pylint"],
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.testing.pytestArgs": ["--no-cov", "tests"],
         "python.testing.pytestEnabled": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "module": "homeassistant",
       "justMyCode": false,
       "args": ["--debug", "-c", "dev-config"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {
@@ -21,7 +21,7 @@
       "module": "homeassistant",
       "justMyCode": false,
       "args": ["--debug", "-c", "dev-config", "--skip-pip"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {
@@ -31,7 +31,7 @@
       "module": "pytest",
       "justMyCode": false,
       "args": ["--picked"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {
@@ -41,7 +41,7 @@
       "module": "pytest",
       "console": "integratedTerminal",
       "args": ["-vv", "${file}"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-VENV_DIR="/home/vscode/.local/ha-venv"
+VENV_DIR="$REPO_ROOT/.venv"
 PY="$VENV_DIR/bin/python"
 PIP="$VENV_DIR/bin/pip"
 

--- a/script/setup
+++ b/script/setup
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-VENV_DIR="/home/vscode/.local/ha-venv"
+VENV_DIR="$REPO_ROOT/.venv"
 PY="$VENV_DIR/bin/python"
 PIP="$VENV_DIR/bin/pip"
 


### PR DESCRIPTION
## Summary
- point the devcontainer VS Code settings at the project-local virtual environment and configure pytest discovery to run from the workspace
- update the setup/bootstrap scripts to create the virtualenv inside the repository and rely on requirements.txt for both runtime and test dependencies

## Testing
- `./script/setup` *(fails: unable to download packages because of SSL certificate verification in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d92ac50c8326bf2fa5c046e2a284