### PR TITLE
Handle sync config entry updates

### DIFF
--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from asyncio import TimeoutError as AsyncioTimeoutError
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
+from inspect import isawaitable
 from json import JSONDecodeError
 from typing import Any, cast
 
@@ -218,4 +219,6 @@ async def async_update_map_refresh_settings(
     new_options = dict(entry.options)
     new_options[MAP_REFRESH_OPTIONS_KEY] = map_options
 
-    await hass.config_entries.async_update_entry(entry, options=new_options)
+    update_result = hass.config_entries.async_update_entry(entry, options=new_options)
+    if isawaitable(update_result):
+        await update_result

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,7 @@
 
 """Tests for helper utilities used by the Kippy integration."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -110,6 +110,25 @@ async def test_async_update_map_refresh_settings_updates_entry() -> None:
         hass, entry_with_options, 2, idle_seconds=600
     )
     hass.config_entries.async_update_entry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_update_map_refresh_settings_handles_sync_update() -> None:
+    """Synchronous update_entry results are handled without awaiting."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="3", options={})
+    hass = MagicMock()
+    hass.config_entries.async_update_entry.return_value = True
+
+    await async_update_map_refresh_settings(hass, entry, 5, live_seconds=30)
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        options=ANY,
+    )
+
+    options = hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert options["map_refresh_settings"]["5"]["live_seconds"] == 30
 
 
 def test_update_pet_data_preserves_and_returns_current() -> None:


### PR DESCRIPTION
## Summary
- allow map refresh settings persistence to handle either coroutine or synchronous results from `async_update_entry`
- add regression coverage ensuring synchronous return values are persisted correctly

## Testing
- isort .
- ruff format
- ruff check
- python -m flake8 custom_components/kippy tests
- python -m pylint custom_components/kippy tests
- python script/hassfest --integration-path custom_components/kippy
- pytest ./tests --cov=custom_components.kippy --cov-report term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e3e197fdf48326b3ebfe165d38c1e2