### PR TITLE
Use box mode for frequency numbers

### DIFF
--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -65,20 +65,28 @@ class KippyUpdateFrequencyNumber(KippyPetEntity, NumberEntity):
         super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} {LOCALIZATION_TECHNOLOGY_GPS} "
-            "Automatic update frequency (hours)"
+            f"{pet_name} {LOCALIZATION_TECHNOLOGY_GPS} Automatic update frequency"
             if pet_name
-            else f"{LOCALIZATION_TECHNOLOGY_GPS} Automatic update frequency (hours)"
+            else f"{LOCALIZATION_TECHNOLOGY_GPS} Automatic update frequency"
         )
         self._attr_unique_id = f"{self._pet_id}_update_frequency"
         self._attr_translation_key = "update_frequency"
 
     @property
-    def native_value(self) -> float | None:
+    def native_value(self) -> int | None:
         value = self._pet_data.get("updateFrequency")
-        return float(value) if value is not None else None
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            try:
+                return int(float(value))
+            except (TypeError, ValueError):
+                return None
 
     async def async_set_native_value(self, value: float) -> None:
+        int_value = int(value)
         kippy_id = normalize_kippy_identifier(self._pet_data)
         gps_val = self._pet_data.get("gpsOnDefault")
         if gps_val is None:
@@ -90,12 +98,14 @@ class KippyUpdateFrequencyNumber(KippyPetEntity, NumberEntity):
 
         if kippy_id is not None:
             data = await self.coordinator.api.modify_kippy_settings(
-                kippy_id, update_frequency=value, gps_on_default=gps_on_default
+                kippy_id,
+                update_frequency=int_value,
+                gps_on_default=gps_on_default,
             )
-            new_value = data.get("update_frequency", value)
+            new_value = data.get("update_frequency", int_value)
             self._pet_data["updateFrequency"] = int(new_value)
         else:
-            self._pet_data["updateFrequency"] = int(value)
+            self._pet_data["updateFrequency"] = int_value
         self.async_write_ha_state()
         self.coordinator.async_update_listeners()
 
@@ -118,16 +128,14 @@ class KippyIdleUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
         super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} Idle update frequency (minutes)"
-            if pet_name
-            else "Idle update frequency (minutes)"
+            f"{pet_name} Idle update frequency" if pet_name else "Idle update frequency"
         )
         self._attr_unique_id = f"{self._pet_id}_idle_refresh_time"
         self._attr_translation_key = "idle_refresh_time"
 
     @property
-    def native_value(self) -> float | None:
-        return float(self.coordinator.idle_refresh) / 60
+    def native_value(self) -> int | None:
+        return int(self.coordinator.idle_refresh / 60)
 
     async def async_set_native_value(self, value: float) -> None:
         seconds = int(value * 60)
@@ -156,16 +164,14 @@ class KippyLiveUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
         super().__init__(coordinator, pet)
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} Live update frequency (seconds)"
-            if pet_name
-            else "Live update frequency (seconds)"
+            f"{pet_name} Live update frequency" if pet_name else "Live update frequency"
         )
         self._attr_unique_id = f"{self._pet_id}_live_refresh_time"
         self._attr_translation_key = "live_refresh_time"
 
     @property
-    def native_value(self) -> float | None:
-        return float(self.coordinator.live_refresh)
+    def native_value(self) -> int | None:
+        return int(self.coordinator.live_refresh)
 
     async def async_set_native_value(self, value: float) -> None:
         seconds = int(value)
@@ -194,15 +200,15 @@ class KippyActivityRefreshDelayNumber(NumberEntity):
         self._pet_data = pet
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} Activity refresh delay (minutes)"
+            f"{pet_name} Activity refresh delay"
             if pet_name
-            else "Activity refresh delay (minutes)"
+            else "Activity refresh delay"
         )
         self._attr_unique_id = f"{self._pet_id}_activity_refresh_delay"
 
     @property
-    def native_value(self) -> float | None:
-        return float(self.timer.delay_minutes)
+    def native_value(self) -> int | None:
+        return int(self.timer.delay_minutes)
 
     async def async_set_native_value(self, value: float) -> None:
         await self.timer.async_set_delay(int(value))

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -57,6 +57,7 @@ class KippyUpdateFrequencyNumber(KippyPetEntity, NumberEntity):
     _attr_native_max_value = 24
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "h"
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]
@@ -109,6 +110,7 @@ class KippyIdleUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "min"
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
@@ -146,6 +148,7 @@ class KippyLiveUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "s"
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
@@ -179,10 +182,11 @@ class KippyLiveUpdateFrequencyNumber(KippyMapEntity, NumberEntity):
 class KippyActivityRefreshDelayNumber(NumberEntity):
     """Number to control activity refresh delay."""
 
-    _attr_native_min_value = 0
+    _attr_native_min_value = 1
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "min"
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
 
     def __init__(self, timer: ActivityRefreshTimer, pet: dict[str, Any]) -> None:
         self.timer = timer

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -5,6 +5,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.components.number import NumberMode
 
 from custom_components.kippy.const import DOMAIN
 from custom_components.kippy.number import (
@@ -34,6 +35,8 @@ async def test_update_frequency_number() -> None:
     )
     number = KippyUpdateFrequencyNumber(coordinator, pet)
     assert number.native_value == 5.0
+    assert number.mode is NumberMode.BOX
+    assert number.native_min_value == 1
     number.async_write_ha_state = MagicMock()
     await number.async_set_native_value(10)
     coordinator.api.modify_kippy_settings.assert_awaited_once_with(
@@ -140,6 +143,10 @@ async def test_idle_and_live_numbers() -> None:
     live = KippyLiveUpdateFrequencyNumber(map_coordinator, pet)
     assert idle.native_value == 5.0
     assert live.native_value == 10.0
+    assert idle.mode is NumberMode.BOX
+    assert live.mode is NumberMode.BOX
+    assert idle.native_min_value == 1
+    assert live.native_min_value == 1
     idle.async_write_ha_state = MagicMock()
     live.async_write_ha_state = MagicMock()
     hass = MagicMock()
@@ -177,6 +184,8 @@ async def test_activity_refresh_delay_number() -> None:
     timer.async_set_delay = AsyncMock()
     number = KippyActivityRefreshDelayNumber(timer, pet)
     assert number.native_value == 2.0
+    assert number.mode is NumberMode.BOX
+    assert number.native_min_value == 1
     number.async_write_ha_state = MagicMock()
     await number.async_set_native_value(5)
     timer.async_set_delay.assert_awaited_once_with(5)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -34,20 +34,20 @@ async def test_update_frequency_number() -> None:
         return_value={"update_frequency": 10}
     )
     number = KippyUpdateFrequencyNumber(coordinator, pet)
-    assert number.native_value == 5.0
+    assert number.native_value == 5
     assert number.mode is NumberMode.BOX
     assert number.native_min_value == 1
     number.async_write_ha_state = MagicMock()
     await number.async_set_native_value(10)
     coordinator.api.modify_kippy_settings.assert_awaited_once_with(
-        2, update_frequency=10.0, gps_on_default=True
+        2, update_frequency=10, gps_on_default=True
     )
     assert pet["updateFrequency"] == 10
     number.async_write_ha_state.assert_called_once()
     coordinator.data = {"pets": [{"petID": 1, "updateFrequency": 20}]}
     number.async_write_ha_state.reset_mock()
     number._handle_coordinator_update()
-    assert number.native_value == 20.0
+    assert number.native_value == 20
     number.async_write_ha_state.assert_called_once()
     info = number.device_info
     assert (DOMAIN, "1") in info["identifiers"]
@@ -104,7 +104,7 @@ async def test_update_frequency_number_sends_current_gps() -> None:
     number.async_write_ha_state = MagicMock()
     await number.async_set_native_value(6)
     coordinator.api.modify_kippy_settings.assert_awaited_once_with(
-        2, update_frequency=6.0, gps_on_default=False
+        2, update_frequency=6, gps_on_default=False
     )
     assert pet["updateFrequency"] == 6
     number.async_write_ha_state.assert_called_once()
@@ -141,8 +141,8 @@ async def test_idle_and_live_numbers() -> None:
 
     idle = KippyIdleUpdateFrequencyNumber(map_coordinator, pet)
     live = KippyLiveUpdateFrequencyNumber(map_coordinator, pet)
-    assert idle.native_value == 5.0
-    assert live.native_value == 10.0
+    assert idle.native_value == 5
+    assert live.native_value == 10
     assert idle.mode is NumberMode.BOX
     assert live.mode is NumberMode.BOX
     assert idle.native_min_value == 1
@@ -183,7 +183,7 @@ async def test_activity_refresh_delay_number() -> None:
     timer.delay_minutes = 2
     timer.async_set_delay = AsyncMock()
     number = KippyActivityRefreshDelayNumber(timer, pet)
-    assert number.native_value == 2.0
+    assert number.native_value == 2
     assert number.mode is NumberMode.BOX
     assert number.native_min_value == 1
     number.async_write_ha_state = MagicMock()


### PR DESCRIPTION
## Summary
- render all Kippy number entities as text-entry boxes instead of sliders
- require the activity refresh delay to be greater than zero
- extend the number entity tests to cover box mode and minimum values

## Testing
- isort .
- ruff format
- ruff check
- python -m flake8 custom_components/kippy tests
- python -m pylint custom_components/kippy tests
- python script/hassfest --integration-path custom_components/kippy
- pytest ./tests --cov=custom_components.kippy --cov-report term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e3ea03f9d08326b2e41f4804d9fc9e