### PR TITLE
Add configurable device refresh interval for Kippy integration

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 DOMAIN = "kippy"
 
 DEFAULT_ACTIVITY_REFRESH_DELAY = 2
+DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES = 15
+MIN_DEVICE_UPDATE_INTERVAL_MINUTES = 1
+MAX_DEVICE_UPDATE_INTERVAL_MINUTES = 24 * 60
 
 # The integration exposes multiple entity types. The list is kept
 # separate so ``async_forward_entry_setups`` can be used in ``__init__``.

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -14,6 +14,18 @@
       }
     }
   },
+  "options": {
+    "error": {
+      "invalid_device_update_interval": "Enter a value between 1 and 1440 minutes."
+    },
+    "step": {
+      "init": {
+        "data": {
+          "device_update_interval_minutes": "Kippy devices update frequency"
+        }
+      }
+    }
+  },
   "exceptions": {
     "no_credentials": {
       "message": "No stored credentials; call login() first"

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -16,6 +16,20 @@
       }
     }
   },
+  "options": {
+    "error": {
+      "invalid_device_update_interval": "Enter a value between 1 and 1440 minutes."
+    },
+    "step": {
+      "init": {
+        "title": "Kippy options",
+        "description": "Configure how often Home Assistant updates Kippy devices.",
+        "data": {
+          "device_update_interval_minutes": "Kippy devices update frequency"
+        }
+      }
+    }
+  },
   "exceptions": {
     "no_credentials": {
       "message": "No stored credentials; call login() first"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,8 +6,12 @@ import pytest
 from aiohttp import ClientError, ClientResponseError
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.kippy.config_flow import KippyConfigFlow
+from custom_components.kippy.const import DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES, DOMAIN
+from custom_components.kippy.helpers import DEVICE_UPDATE_INTERVAL_KEY
 
 
 @pytest.mark.asyncio
@@ -81,3 +85,42 @@ def test_config_flow_is_matching() -> None:
             return False
 
     assert not flow.is_matching(DummyFlow())
+
+
+@pytest.mark.asyncio
+async def test_options_flow_success(hass: HomeAssistant) -> None:
+    """Options flow stores the configured update interval."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry.add_to_hass(hass)
+    flow = KippyConfigFlow.async_get_options_flow(entry)
+    assert flow is not None
+    flow.hass = hass
+    result = await flow.async_step_init()
+    assert result["type"].value == "form"
+    required_field = next(iter(result["data_schema"].schema))
+    assert required_field.schema == DEVICE_UPDATE_INTERVAL_KEY
+    assert callable(required_field.default)
+    assert required_field.default() == str(DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES)
+
+    result = await flow.async_step_init({DEVICE_UPDATE_INTERVAL_KEY: "30"})
+    assert result["type"].value == "create_entry"
+    assert result["data"][DEVICE_UPDATE_INTERVAL_KEY] == 30
+
+
+@pytest.mark.asyncio
+async def test_options_flow_validates_interval(hass: HomeAssistant) -> None:
+    """Invalid intervals return the form with an error."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry.add_to_hass(hass)
+    flow = KippyConfigFlow.async_get_options_flow(entry)
+    flow.hass = hass
+
+    result = await flow.async_step_init({DEVICE_UPDATE_INTERVAL_KEY: "0"})
+    assert result["type"].value == "form"
+    assert result["errors"]["base"] == "invalid_device_update_interval"
+
+    result = await flow.async_step_init({DEVICE_UPDATE_INTERVAL_KEY: "abc"})
+    assert result["type"].value == "form"
+    assert result["errors"]["base"] == "invalid_device_update_interval"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,14 +8,22 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.kippy import helpers as helpers_module
-from custom_components.kippy.const import DOMAIN
+from custom_components.kippy.const import (
+    DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES,
+    DOMAIN,
+    MAX_DEVICE_UPDATE_INTERVAL_MINUTES,
+    MIN_DEVICE_UPDATE_INTERVAL_MINUTES,
+)
 from custom_components.kippy.helpers import (
+    DEVICE_UPDATE_INTERVAL_KEY,
     MAP_REFRESH_IDLE_KEY,
     MAP_REFRESH_LIVE_KEY,
     MapRefreshSettings,
     async_update_map_refresh_settings,
     build_device_info,
+    get_device_update_interval_minutes,
     get_map_refresh_settings,
+    normalize_device_update_interval,
     normalize_kippy_identifier,
     update_pet_data,
 )
@@ -206,3 +214,52 @@ async def test_async_update_map_refresh_settings_no_updates() -> None:
     await async_update_map_refresh_settings(hass, entry, 4)
 
     hass.config_entries.async_update_entry.assert_not_awaited()
+
+
+def test_normalize_device_update_interval() -> None:
+    """Normalize helper accepts valid values and rejects invalid ones."""
+
+    assert (
+        normalize_device_update_interval(MIN_DEVICE_UPDATE_INTERVAL_MINUTES)
+        == MIN_DEVICE_UPDATE_INTERVAL_MINUTES
+    )
+    assert (
+        normalize_device_update_interval(str(MAX_DEVICE_UPDATE_INTERVAL_MINUTES))
+        == MAX_DEVICE_UPDATE_INTERVAL_MINUTES
+    )
+    assert normalize_device_update_interval(None) is None
+    assert normalize_device_update_interval(0) is None
+    assert normalize_device_update_interval(" ") is None
+    assert normalize_device_update_interval("abc") is None
+
+
+def test_get_device_update_interval_minutes_defaults() -> None:
+    """Default interval is used when the option is missing or invalid."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    assert (
+        get_device_update_interval_minutes(entry)
+        == DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={}, options={DEVICE_UPDATE_INTERVAL_KEY: "abc"}
+    )
+    assert (
+        get_device_update_interval_minutes(entry)
+        == DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES
+    )
+
+
+def test_get_device_update_interval_minutes_from_options() -> None:
+    """Valid option value is returned unchanged."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={DEVICE_UPDATE_INTERVAL_KEY: MIN_DEVICE_UPDATE_INTERVAL_MINUTES + 5},
+    )
+    assert (
+        get_device_update_interval_minutes(entry)
+        == MIN_DEVICE_UPDATE_INTERVAL_MINUTES + 5
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 """Tests for integration setup and unload."""
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ from custom_components.kippy.coordinator import (
     ActivityRefreshContext,
     CoordinatorContext,
 )
+from custom_components.kippy.helpers import DEVICE_UPDATE_INTERVAL_KEY
 
 
 @pytest.mark.asyncio
@@ -195,10 +197,71 @@ async def test_async_setup_entry_handles_expired_pet(hass: HomeAssistant) -> Non
     (activity_context, pet_ids), _ = act_cls.call_args
     assert activity_context is map_context
     assert pet_ids == [1]
-    (timer_context, timer_pet_id), _ = timer_cls.call_args
+    (timer_context, _), _ = timer_cls.call_args
     assert isinstance(timer_context, ActivityRefreshContext)
     assert timer_context.map is map_coord
-    assert timer_pet_id == 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_updates_interval_on_option_change(
+    hass: HomeAssistant,
+) -> None:
+    """Options update listener refreshes the coordinator interval."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_EMAIL: "a", CONF_PASSWORD: "b"},
+        entry_id="1",
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    api = AsyncMock()
+    api.login = AsyncMock()
+    data_coord = AsyncMock()
+    data_coord.async_config_entry_first_refresh = AsyncMock()
+    data_coord.data = {"pets": []}
+    data_coord.set_update_interval_minutes = MagicMock()
+    forward = AsyncMock()
+
+    listeners: list[Callable[[HomeAssistant, MockConfigEntry], Awaitable[None]]] = []
+
+    def _add_listener(callback):
+        listeners.append(callback)
+        return lambda: None
+
+    entry.add_update_listener = MagicMock(side_effect=_add_listener)
+
+    with (
+        patch("custom_components.kippy.aiohttp_client.async_get_clientsession"),
+        patch("custom_components.kippy.KippyApi.async_create", return_value=api),
+        patch(
+            "custom_components.kippy.KippyDataUpdateCoordinator",
+            return_value=data_coord,
+        ),
+        patch(
+            "custom_components.kippy.KippyMapDataUpdateCoordinator",
+            return_value=AsyncMock(),
+        ),
+        patch(
+            "custom_components.kippy.KippyActivityCategoriesDataUpdateCoordinator",
+            return_value=AsyncMock(),
+        ),
+        patch("custom_components.kippy.ActivityRefreshTimer", return_value=MagicMock()),
+        patch.object(hass.config_entries, "async_forward_entry_setups", forward),
+    ):
+        assert await async_setup_entry(hass, entry)
+
+    assert listeners
+    callback = listeners[0]
+    updated_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry.data,
+        entry_id=entry.entry_id,
+        options={DEVICE_UPDATE_INTERVAL_KEY: 25},
+    )
+    await callback(hass, updated_entry)
+    data_coord.set_update_interval_minutes.assert_called_once_with(25)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an integration-wide option to configure the GetPetKippyList polling interval and reuse it across coordinators
- ensure the base coordinator reloads the entry when new pets are detected and surface strings for the new option UI
- extend helper and config flow tests to cover interval parsing, validation, and option handling

## Testing
- `pytest --disable-warnings -q`
- `isort .`
- `ruff format .`
- `ruff check .`
- `python -m flake8 custom_components/kippy tests`
- `python -m pylint custom_components/kippy tests`
- `python script/hassfest --integration-path custom_components/kippy`


------
https://chatgpt.com/codex/tasks/task_e_68e40148d07083269137c86c32dce5ff