### PR TITLE
Fix deprecated options flow config_entry assignment

### DIFF
--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -107,7 +107,7 @@ class KippyOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
 
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None) -> FlowResult:
         """Handle the options step for configuring refresh interval."""
@@ -121,11 +121,11 @@ class KippyOptionsFlowHandler(config_entries.OptionsFlow):
             if minutes is None:
                 errors["base"] = "invalid_device_update_interval"
             else:
-                options = dict(self.config_entry.options)
+                options = dict(self._config_entry.options)
                 options[DEVICE_UPDATE_INTERVAL_KEY] = minutes
                 return self.async_create_entry(title="", data=options)
 
-        current = get_device_update_interval(self.config_entry)
+        current = get_device_update_interval(self._config_entry)
         data_schema = vol.Schema(
             {
                 vol.Required(


### PR DESCRIPTION
## Summary
- update the options flow handler to avoid assigning the deprecated `config_entry` attribute directly

## Testing
- isort .
- ruff format
- ruff check
- python -m flake8 custom_components/kippy tests
- python -m pylint custom_components/kippy tests
- python script/hassfest --integration-path custom_components/kippy
- pytest ./tests --cov=custom_components.kippy --cov-report term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e43040fedc8326b006dd660694caa0