### PR TITLE
1.0.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,9 +34,10 @@
       // Please keep this file in sync with settings in .vscode/settings.default.json
       "settings": {
         "python.experiments.optOutFrom": ["pythonTestAdapter"],
-        "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
+        "python.testing.cwd": "${containerWorkspaceFolder}",
         "pylint.importStrategy": "fromEnvironment",
-        "pylint.path": ["/home/vscode/.local/ha-venv/bin/pylint"],
+        "pylint.path": ["${containerWorkspaceFolder}/.venv/bin/pylint"],
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.testing.pytestArgs": ["--no-cov", "tests"],
         "python.testing.pytestEnabled": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "module": "homeassistant",
       "justMyCode": false,
       "args": ["--debug", "-c", "dev-config"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {
@@ -21,7 +21,7 @@
       "module": "homeassistant",
       "justMyCode": false,
       "args": ["--debug", "-c", "dev-config", "--skip-pip"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {
@@ -31,7 +31,7 @@
       "module": "pytest",
       "justMyCode": false,
       "args": ["--picked"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {
@@ -41,7 +41,7 @@
       "module": "pytest",
       "console": "integratedTerminal",
       "args": ["-vv", "${file}"],
-      "python": "/home/vscode/.local/ha-venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "env": { "PYTHONPATH": "${workspaceFolder}" }
     },
     {

--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any, Awaitable
+
 from aiohttp import ClientResponseError
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -21,6 +24,7 @@ from .coordinator import (
 )
 from .helpers import (
     API_EXCEPTIONS,
+    get_device_update_interval,
     get_map_refresh_settings,
     is_pet_subscription_active,
     normalize_kippy_identifier,
@@ -40,7 +44,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await api.login(email, password)
-        coordinator = KippyDataUpdateCoordinator(hass, entry, api)
+
+        async def _async_reload_entry() -> None:
+            if entry.state is not ConfigEntryState.LOADED:
+                return
+            await hass.config_entries.async_reload(entry.entry_id)
+
+        coordinator = KippyDataUpdateCoordinator(
+            hass, entry, api, on_new_pets=_async_reload_entry
+        )
         await coordinator.async_config_entry_first_refresh()
 
         context = CoordinatorContext(hass, entry, api)
@@ -71,6 +83,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "activity_timers": activity_timers,
     }
 
+    async def _async_options_updated(
+        hass: HomeAssistant, updated_entry: ConfigEntry
+    ) -> None:
+        data = hass.data.get(DOMAIN, {}).get(updated_entry.entry_id)
+        if not data:
+            return
+        base_coordinator: KippyDataUpdateCoordinator = data["coordinator"]
+        base_coordinator.set_update_interval_minutes(
+            get_device_update_interval(updated_entry)
+        )
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -84,6 +109,26 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if data is not None:
             for timer in data.get("activity_timers", {}).values():
                 timer.async_cancel()
+            shutdown_tasks: list[Awaitable[Any]] = []
+
+            def _collect_shutdown(target: Any) -> None:
+                shutdown = getattr(target, "async_shutdown", None)
+                if shutdown is not None:
+                    shutdown_tasks.append(shutdown())
+
+            coordinator = data.get("coordinator")
+            if coordinator is not None:
+                _collect_shutdown(coordinator)
+
+            for map_coordinator in data.get("map_coordinators", {}).values():
+                _collect_shutdown(map_coordinator)
+
+            activity_coordinator = data.get("activity_coordinator")
+            if activity_coordinator is not None:
+                _collect_shutdown(activity_coordinator)
+
+            if shutdown_tasks:
+                await asyncio.gather(*shutdown_tasks)
     return unload_ok
 
 

--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -8,10 +8,21 @@ import voluptuous as vol
 from aiohttp import ClientError, ClientResponseError
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-from homeassistant.helpers import aiohttp_client
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import aiohttp_client, selector
 
 from .api import KippyApi
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    MAX_DEVICE_UPDATE_INTERVAL_MINUTES,
+    MIN_DEVICE_UPDATE_INTERVAL_MINUTES,
+)
+from .helpers import (
+    DEVICE_UPDATE_INTERVAL_KEY,
+    get_device_update_interval,
+    normalize_device_update_interval,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +36,7 @@ class KippyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Return True when ``other_flow`` targets the same integration."""
         return isinstance(other_flow, KippyConfigFlow)
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -80,4 +91,59 @@ class KippyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        return KippyOptionsFlowHandler(config_entry)
+
+
+class KippyOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle the options flow for Kippy."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        """Handle the options step for configuring refresh interval."""
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            minutes = normalize_device_update_interval(
+                user_input.get(DEVICE_UPDATE_INTERVAL_KEY)
+            )
+            if minutes is None:
+                errors["base"] = "invalid_device_update_interval"
+            else:
+                options = dict(self.config_entry.options)
+                options[DEVICE_UPDATE_INTERVAL_KEY] = minutes
+                return self.async_create_entry(title="", data=options)
+
+        current = get_device_update_interval(self.config_entry)
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    DEVICE_UPDATE_INTERVAL_KEY,
+                    default=current,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=MIN_DEVICE_UPDATE_INTERVAL_MINUTES,
+                        max=MAX_DEVICE_UPDATE_INTERVAL_MINUTES,
+                        step=1,
+                        unit_of_measurement="min",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=data_schema,
+            errors=errors,
         )

--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -107,7 +107,7 @@ class KippyOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
 
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None) -> FlowResult:
         """Handle the options step for configuring refresh interval."""
@@ -121,11 +121,11 @@ class KippyOptionsFlowHandler(config_entries.OptionsFlow):
             if minutes is None:
                 errors["base"] = "invalid_device_update_interval"
             else:
-                options = dict(self.config_entry.options)
+                options = dict(self._config_entry.options)
                 options[DEVICE_UPDATE_INTERVAL_KEY] = minutes
                 return self.async_create_entry(title="", data=options)
 
-        current = get_device_update_interval(self.config_entry)
+        current = get_device_update_interval(self._config_entry)
         data_schema = vol.Schema(
             {
                 vol.Required(

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -116,6 +116,11 @@ OPERATING_STATUS_MAP: dict[int, str] = {
     OPERATING_STATUS.ENERGY_SAVING: "energy_saving",
 }
 
+# Mapping of operating status strings back to their numeric codes.
+OPERATING_STATUS_REVERSE_MAP: dict[str, int] = {
+    value: key for key, value in OPERATING_STATUS_MAP.items()
+}
+
 # App action identifiers used by the API.
 APP_ACTION = SimpleNamespace(
     TURN_LIVE_TRACKING_ON=2,

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 DOMAIN = "kippy"
 
 DEFAULT_ACTIVITY_REFRESH_DELAY = 2
+DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES = 15
+MIN_DEVICE_UPDATE_INTERVAL_MINUTES = 1
+MAX_DEVICE_UPDATE_INTERVAL_MINUTES = 24 * 60
 
 # The integration exposes multiple entity types. The list is kept
 # separate so ``async_forward_entry_setups`` can be used in ``__init__``.

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Iterable
+from typing import Any, Awaitable, Callable, Iterable
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -23,7 +25,7 @@ from .const import (
     OPERATING_STATUS_MAP,
     OPERATING_STATUS_REVERSE_MAP,
 )
-from .helpers import API_EXCEPTIONS, MapRefreshSettings
+from .helpers import API_EXCEPTIONS, MapRefreshSettings, get_device_update_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,28 +47,110 @@ class KippyDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the Kippy API."""
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, api: KippyApi
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        api: KippyApi,
+        on_new_pets: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         """Initialize the coordinator."""
         self.api = api
         self.config_entry = config_entry
+        self._on_new_pets = on_new_pets
+        self._known_pet_ids: set[str] | None = None
+        self._pending_reload = False
+        self._reload_task: asyncio.Task[None] | None = None
+        update_minutes = get_device_update_interval(config_entry)
         kwargs: dict[str, Any] = {
             "name": DOMAIN,
-            # Fetching the pet list does not need to happen on a schedule.
-            # The coordinator will only update when explicitly requested.
-            "update_interval": None,
+            "update_interval": timedelta(minutes=update_minutes),
         }
         if _HAS_CONFIG_ENTRY:
             kwargs["config_entry"] = config_entry
         super().__init__(hass, _LOGGER, **kwargs)
 
+    def set_update_interval_minutes(self, minutes: int) -> None:
+        """Update the refresh interval used for fetching pet data."""
+
+        interval = timedelta(minutes=minutes)
+        if self.update_interval == interval:
+            return
+
+        self.update_interval = interval
+
+        # Apply the new interval immediately by rescheduling the refresh task.
+        self._schedule_refresh()
+
+    def _handle_new_pets(self, pets: list[dict[str, Any]]) -> None:
+        """Schedule a reload when new pets are detected."""
+
+        if isinstance(pets, list):
+            pets_iterable: list[Any] = pets
+        else:
+            try:
+                pets_iterable = list(pets or [])
+            except TypeError:
+                pets_iterable = []
+
+        new_ids = {
+            str(pet["petID"])
+            for pet in pets_iterable
+            if isinstance(pet, dict) and pet.get("petID") is not None
+        }
+
+        if self._known_pet_ids is None:
+            self._known_pet_ids = new_ids
+            return
+
+        if not self._on_new_pets or self._pending_reload:
+            self._known_pet_ids = new_ids
+            return
+
+        added = new_ids - self._known_pet_ids
+        self._known_pet_ids = new_ids
+
+        if not added:
+            return
+
+        self._pending_reload = True
+
+        async def _reload_wrapper() -> None:
+            try:
+                await self._on_new_pets()
+            finally:
+                self._pending_reload = False
+
+        task = self.hass.async_create_task(_reload_wrapper())
+        self._reload_task = task
+
+        def _clear_reload_task(_future: asyncio.Future[Any]) -> None:
+            if self._reload_task is task:
+                self._reload_task = None
+
+        task.add_done_callback(_clear_reload_task)
+
     async def _async_update_data(self):
         """Fetch data from the API endpoint."""
         # ``get_pet_kippy_list`` internally ensures a valid login session.
         try:
-            return {"pets": await self.api.get_pet_kippy_list()}
+            pets = await self.api.get_pet_kippy_list()
         except API_EXCEPTIONS as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+        self._handle_new_pets(pets)
+        return {"pets": pets}
+
+    async def async_shutdown(self) -> None:
+        """Cancel any pending reload task and shut down the coordinator."""
+
+        task = self._reload_task
+        self._reload_task = None
+        if task and not task.done():
+            current_task = asyncio.current_task()
+            if task is not current_task:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+        await super().async_shutdown()
 
 
 def _normalize_operating_status(value: Any) -> tuple[int | None, str | None]:

--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from asyncio import TimeoutError as AsyncioTimeoutError
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
+from inspect import isawaitable
 from json import JSONDecodeError
 from typing import Any, cast
 
@@ -218,4 +219,6 @@ async def async_update_map_refresh_settings(
     new_options = dict(entry.options)
     new_options[MAP_REFRESH_OPTIONS_KEY] = map_options
 
-    await hass.config_entries.async_update_entry(entry, options=new_options)
+    update_result = hass.config_entries.async_update_entry(entry, options=new_options)
+    if isawaitable(update_result):
+        await update_result

--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -14,7 +14,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN
+from .const import (
+    DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES,
+    DOMAIN,
+    MAX_DEVICE_UPDATE_INTERVAL_MINUTES,
+    MIN_DEVICE_UPDATE_INTERVAL_MINUTES,
+)
 
 API_EXCEPTIONS: tuple[type[Exception], ...] = (
     ClientError,
@@ -27,6 +32,8 @@ MAP_REFRESH_OPTIONS_KEY = "map_refresh_settings"
 MAP_REFRESH_IDLE_KEY = "idle_seconds"
 MAP_REFRESH_LIVE_KEY = "live_seconds"
 
+DEVICE_UPDATE_INTERVAL_KEY = "device_update_interval"
+
 
 @dataclass(slots=True)
 class MapRefreshSettings:
@@ -34,6 +41,37 @@ class MapRefreshSettings:
 
     idle_seconds: int = 300
     live_seconds: int = 10
+
+
+def normalize_device_update_interval(value: Any) -> int | None:
+    """Return a sanitized minutes value for the device update interval."""
+
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    try:
+        minutes = int(value)
+    except (TypeError, ValueError):
+        return None
+    if not (
+        MIN_DEVICE_UPDATE_INTERVAL_MINUTES
+        <= minutes
+        <= MAX_DEVICE_UPDATE_INTERVAL_MINUTES
+    ):
+        return None
+    return minutes
+
+
+def get_device_update_interval(entry: ConfigEntry) -> int:
+    """Return the configured minutes between device updates."""
+
+    normalized = normalize_device_update_interval(
+        entry.options.get(DEVICE_UPDATE_INTERVAL_KEY)
+    )
+    if normalized is not None:
+        return normalized
+    return DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES
 
 
 def build_device_name(pet: Mapping[str, Any], prefix: str = "Kippy") -> str:

--- a/custom_components/kippy/manifest.json
+++ b/custom_components/kippy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ThomasHFWright/kippy-homeassistant/issues",
   "requirements": [],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -14,6 +14,18 @@
       }
     }
   },
+  "options": {
+    "error": {
+      "invalid_device_update_interval": "Enter a value between 1 and 1440 minutes."
+    },
+    "step": {
+      "init": {
+        "data": {
+          "device_update_interval": "Kippy devices update frequency"
+        }
+      }
+    }
+  },
   "exceptions": {
     "no_credentials": {
       "message": "No stored credentials; call login() first"
@@ -29,6 +41,11 @@
     }
   },
   "entity": {
+    "number": {
+      "device_update_frequency": {
+        "name": "Kippy devices update frequency"
+      }
+    },
     "binary_sensor": {
       "firmware_upgrade_available": {
         "name": "Firmware Upgrade available",

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -16,6 +16,20 @@
       }
     }
   },
+  "options": {
+    "error": {
+      "invalid_device_update_interval": "Enter a value between 1 and 1440 minutes."
+    },
+    "step": {
+      "init": {
+        "title": "Kippy options",
+        "description": "Configure how often Home Assistant updates Kippy devices.",
+        "data": {
+          "device_update_interval": "Kippy devices update frequency"
+        }
+      }
+    }
+  },
   "exceptions": {
     "no_credentials": {
       "message": "No stored credentials; call login() first"
@@ -31,6 +45,11 @@
     }
   },
   "entity": {
+    "number": {
+      "device_update_frequency": {
+        "name": "Kippy devices update frequency"
+      }
+    },
     "binary_sensor": {
       "firmware_upgrade_available": {
         "name": "Firmware Upgrade available",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-VENV_DIR="/home/vscode/.local/ha-venv"
+VENV_DIR="$REPO_ROOT/.venv"
 PY="$VENV_DIR/bin/python"
 PIP="$VENV_DIR/bin/pip"
 

--- a/script/setup
+++ b/script/setup
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-VENV_DIR="/home/vscode/.local/ha-venv"
+VENV_DIR="$REPO_ROOT/.venv"
 PY="$VENV_DIR/bin/python"
 PIP="$VENV_DIR/bin/pip"
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.kippy.const import (
+    DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES,
     LOCALIZATION_TECHNOLOGY_LBS,
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
@@ -22,12 +23,27 @@ from custom_components.kippy.coordinator import (
     KippyDataUpdateCoordinator,
     KippyMapDataUpdateCoordinator,
 )
+from custom_components.kippy.helpers import DEVICE_UPDATE_INTERVAL_KEY
+
+
+def make_config_entry() -> MagicMock:
+    """Return a mock config entry with default options."""
+
+    entry = MagicMock()
+    entry.options = {}
+    return entry
 
 
 def make_context(hass: MagicMock, api: MagicMock | None = None) -> CoordinatorContext:
     """Return a coordinator context for tests."""
 
-    return CoordinatorContext(hass, MagicMock(), api or MagicMock())
+    return CoordinatorContext(hass, make_config_entry(), api or MagicMock())
+
+
+def _create_task(coro):
+    """Create a task for the provided coroutine."""
+
+    return asyncio.create_task(coro)
 
 
 @pytest.mark.asyncio
@@ -74,7 +90,12 @@ async def test_data_coordinator_update_success() -> None:
     hass.loop = asyncio.get_running_loop()
     api = MagicMock()
     api.get_pet_kippy_list = AsyncMock(return_value=[{"petID": 1}])
-    coordinator = KippyDataUpdateCoordinator(hass, MagicMock(), api)
+    config_entry = make_config_entry()
+    hass.async_create_task = MagicMock(side_effect=_create_task)
+    coordinator = KippyDataUpdateCoordinator(hass, config_entry, api)
+    assert coordinator.update_interval == timedelta(
+        minutes=DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES
+    )
     data = await coordinator._async_update_data()
     assert data == {"pets": [{"petID": 1}]}
 
@@ -86,9 +107,105 @@ async def test_data_coordinator_update_failure() -> None:
     hass.loop = asyncio.get_running_loop()
     api = MagicMock()
     api.get_pet_kippy_list = AsyncMock(side_effect=RuntimeError)
-    coordinator = KippyDataUpdateCoordinator(hass, MagicMock(), api)
+    coordinator = KippyDataUpdateCoordinator(hass, make_config_entry(), api)
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_uses_configured_update_interval() -> None:
+    """Configured options influence the coordinator update interval."""
+
+    hass = MagicMock()
+    hass.loop = asyncio.get_running_loop()
+    hass.async_create_task = MagicMock(side_effect=_create_task)
+    api = MagicMock()
+    api.get_pet_kippy_list = AsyncMock(return_value=[])
+    entry = make_config_entry()
+    entry.options[DEVICE_UPDATE_INTERVAL_KEY] = 45
+
+    coordinator = KippyDataUpdateCoordinator(hass, entry, api)
+
+    assert coordinator.update_interval == timedelta(minutes=45)
+
+    with patch.object(coordinator, "_schedule_refresh") as schedule:
+        coordinator.set_update_interval_minutes(5)
+
+    assert coordinator.update_interval == timedelta(minutes=5)
+    schedule.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_detects_new_pets_and_reloads() -> None:
+    """New pets trigger the reload callback exactly once."""
+
+    hass = MagicMock()
+    hass.loop = asyncio.get_running_loop()
+    hass.async_create_task = MagicMock(side_effect=_create_task)
+    api = MagicMock()
+    api.get_pet_kippy_list = AsyncMock(
+        side_effect=[
+            [{"petID": 1}],
+            [{"petID": 1}, {"petID": 2}],
+            [{"petID": 1}, {"petID": 2}],
+        ]
+    )
+    entry = make_config_entry()
+    reload_calls = 0
+
+    async def _reload() -> None:
+        nonlocal reload_calls
+        reload_calls += 1
+
+    coordinator = KippyDataUpdateCoordinator(hass, entry, api, on_new_pets=_reload)
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+    await asyncio.sleep(0)
+    await coordinator._async_update_data()
+    assert reload_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_data_coordinator_shutdown_cancels_reload_task() -> None:
+    """Pending reload task is cancelled during shutdown."""
+
+    hass = MagicMock()
+    hass.loop = asyncio.get_running_loop()
+    created_tasks: list[asyncio.Task[None]] = []
+
+    def _create_task(coro):
+        task: asyncio.Task[None] = asyncio.create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    hass.async_create_task = MagicMock(side_effect=_create_task)
+    api = MagicMock()
+    reload_event = asyncio.Event()
+
+    async def _reload() -> None:
+        await reload_event.wait()
+
+    coordinator = KippyDataUpdateCoordinator(
+        hass, make_config_entry(), api, on_new_pets=_reload
+    )
+    coordinator._known_pet_ids = {"1"}
+    coordinator._handle_new_pets(
+        [
+            {"petID": 1},
+            {"petID": 2},
+        ]
+    )
+
+    await asyncio.sleep(0)
+    assert coordinator._reload_task is not None
+
+    await coordinator.async_shutdown()
+
+    assert not reload_event.is_set()
+    assert coordinator._reload_task is None
+    assert created_tasks
+    assert all(task.cancelled() for task in created_tasks)
 
 
 @pytest.mark.asyncio
@@ -229,7 +346,7 @@ def test_has_config_entry_branches(monkeypatch) -> None:
     hass = MagicMock()
     hass.loop = loop
     api = MagicMock()
-    KippyDataUpdateCoordinator(hass, MagicMock(), api)
+    KippyDataUpdateCoordinator(hass, make_config_entry(), api)
     KippyMapDataUpdateCoordinator(make_context(hass, api), 1)
     KippyActivityCategoriesDataUpdateCoordinator(make_context(hass, api), [])
     assert all("config_entry" in c for c in calls)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -46,6 +46,28 @@ async def test_process_new_data_maps_operating_status() -> None:
 
 
 @pytest.mark.asyncio
+async def test_process_new_data_accepts_string_operating_status() -> None:
+    """process_new_data should keep string operating status values stable."""
+    hass = MagicMock()
+    hass.loop = asyncio.get_running_loop()
+    coordinator = KippyMapDataUpdateCoordinator(make_context(hass), 1)
+
+    coordinator.process_new_data({"operating_status": "live"})
+
+    assert (
+        coordinator.data["operating_status"]
+        == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
+    )
+
+    coordinator.process_new_data({"operating_status": "IDLE"})
+
+    assert (
+        coordinator.data["operating_status"]
+        == OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]
+    )
+
+
+@pytest.mark.asyncio
 async def test_data_coordinator_update_success() -> None:
     """_async_update_data returns pets list on success."""
     hass = MagicMock()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,7 @@
 
 """Tests for helper utilities used by the Kippy integration."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -110,6 +110,25 @@ async def test_async_update_map_refresh_settings_updates_entry() -> None:
         hass, entry_with_options, 2, idle_seconds=600
     )
     hass.config_entries.async_update_entry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_update_map_refresh_settings_handles_sync_update() -> None:
+    """Synchronous update_entry results are handled without awaiting."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="3", options={})
+    hass = MagicMock()
+    hass.config_entries.async_update_entry.return_value = True
+
+    await async_update_map_refresh_settings(hass, entry, 5, live_seconds=30)
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        options=ANY,
+    )
+
+    options = hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert options["map_refresh_settings"]["5"]["live_seconds"] == 30
 
 
 def test_update_pet_data_preserves_and_returns_current() -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -6,15 +6,107 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.number import NumberMode
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.kippy.const import DOMAIN
+from custom_components.kippy.const import DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES, DOMAIN
+from custom_components.kippy.helpers import DEVICE_UPDATE_INTERVAL_KEY
 from custom_components.kippy.number import (
     KippyActivityRefreshDelayNumber,
+    KippyDeviceUpdateFrequencyNumber,
     KippyIdleUpdateFrequencyNumber,
     KippyLiveUpdateFrequencyNumber,
     KippyUpdateFrequencyNumber,
     async_setup_entry,
 )
+
+
+@pytest.mark.asyncio
+async def test_device_update_frequency_number_native_value() -> None:
+    """Device update frequency number reflects config entry options."""
+
+    entry = MockConfigEntry(options={}, entry_id="entry")
+    coordinator = MagicMock()
+    coordinator.config_entry = entry
+    coordinator.async_add_listener = MagicMock()
+    coordinator.set_update_interval_minutes = MagicMock()
+    number = KippyDeviceUpdateFrequencyNumber(coordinator)
+    assert number.native_value == DEFAULT_DEVICE_UPDATE_INTERVAL_MINUTES
+
+    configured_entry = MockConfigEntry(
+        options={DEVICE_UPDATE_INTERVAL_KEY: 30}, entry_id="entry"
+    )
+    configured_coordinator = MagicMock()
+    configured_coordinator.config_entry = configured_entry
+    configured_coordinator.async_add_listener = MagicMock()
+    configured_coordinator.set_update_interval_minutes = MagicMock()
+    configured_number = KippyDeviceUpdateFrequencyNumber(configured_coordinator)
+    assert configured_number.native_value == 30
+
+
+@pytest.mark.asyncio
+async def test_device_update_frequency_number_updates_entry() -> None:
+    """Setting the device update frequency persists the new value."""
+
+    entry = MockConfigEntry(options={}, entry_id="entry")
+    coordinator = MagicMock()
+    coordinator.config_entry = entry
+    coordinator.async_add_listener = MagicMock()
+    coordinator.set_update_interval_minutes = MagicMock()
+    number = KippyDeviceUpdateFrequencyNumber(coordinator)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    number.hass = hass
+    number.async_write_ha_state = MagicMock()
+
+    await number.async_set_native_value(25)
+
+    hass.config_entries.async_update_entry.assert_called_once()
+    update_call = hass.config_entries.async_update_entry.call_args
+    assert update_call.args[0] is entry
+    assert update_call.kwargs["options"][DEVICE_UPDATE_INTERVAL_KEY] == 25
+    coordinator.set_update_interval_minutes.assert_called_once_with(25)
+    number.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_device_update_frequency_number_rejects_invalid() -> None:
+    """Invalid values raise an error and do not update options."""
+
+    entry = MockConfigEntry(options={}, entry_id="entry")
+    coordinator = MagicMock()
+    coordinator.config_entry = entry
+    coordinator.async_add_listener = MagicMock()
+    coordinator.set_update_interval_minutes = MagicMock()
+    number = KippyDeviceUpdateFrequencyNumber(coordinator)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    number.hass = hass
+
+    with pytest.raises(ValueError):
+        await number.async_set_native_value(0)
+
+    hass.config_entries.async_update_entry.assert_not_called()
+    coordinator.set_update_interval_minutes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_device_update_frequency_number_listeners(hass) -> None:
+    """The number registers and removes config entry update listeners."""
+
+    entry = MockConfigEntry(options={}, entry_id="entry")
+    unsub = MagicMock()
+    entry.add_update_listener = MagicMock(return_value=unsub)
+    coordinator = MagicMock()
+    coordinator.config_entry = entry
+    coordinator.async_add_listener = MagicMock()
+    number = KippyDeviceUpdateFrequencyNumber(coordinator)
+    number.hass = hass
+
+    await number.async_added_to_hass()
+    entry.add_update_listener.assert_called_once()
+
+    await number.async_will_remove_from_hass()
+    unsub.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -217,6 +309,7 @@ async def test_number_async_setup_entry_creates_entities() -> None:
     await async_setup_entry(hass, entry, async_add_entities)
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args[0][0]
+    assert any(isinstance(e, KippyDeviceUpdateFrequencyNumber) for e in entities)
     assert any(isinstance(e, KippyUpdateFrequencyNumber) for e in entities)
     assert any(isinstance(e, KippyIdleUpdateFrequencyNumber) for e in entities)
     assert any(isinstance(e, KippyLiveUpdateFrequencyNumber) for e in entities)
@@ -242,7 +335,10 @@ async def test_number_async_setup_entry_no_pets() -> None:
     }
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)
-    async_add_entities.assert_called_once_with([])
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], KippyDeviceUpdateFrequencyNumber)
 
 
 @pytest.mark.asyncio
@@ -266,7 +362,12 @@ async def test_number_async_setup_entry_missing_map() -> None:
     await async_setup_entry(hass, entry, async_add_entities)
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args[0][0]
-    assert all(isinstance(e, KippyUpdateFrequencyNumber) for e in entities)
+    assert any(isinstance(e, KippyDeviceUpdateFrequencyNumber) for e in entities)
+    assert any(isinstance(e, KippyUpdateFrequencyNumber) for e in entities)
+    assert all(
+        isinstance(e, (KippyDeviceUpdateFrequencyNumber, KippyUpdateFrequencyNumber))
+        for e in entities
+    )
 
 
 @pytest.mark.asyncio
@@ -288,7 +389,10 @@ async def test_number_async_setup_entry_expired_pet() -> None:
     }
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)
-    async_add_entities.assert_called_once_with([])
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], KippyDeviceUpdateFrequencyNumber)
 
 
 def test_numbers_raise_for_sync_setters() -> None:
@@ -297,6 +401,7 @@ def test_numbers_raise_for_sync_setters() -> None:
     coordinator = MagicMock()
     coordinator.data = {"pets": []}
     coordinator.async_add_listener = MagicMock()
+    coordinator.config_entry = MockConfigEntry(options={}, entry_id="entry")
     gps_number = KippyUpdateFrequencyNumber(coordinator, {"petID": 1})
     with pytest.raises(NotImplementedError):
         gps_number.set_native_value(1)
@@ -316,3 +421,7 @@ def test_numbers_raise_for_sync_setters() -> None:
     activity_number = KippyActivityRefreshDelayNumber(timer, {"petID": 4})
     with pytest.raises(NotImplementedError):
         activity_number.set_native_value(1)
+
+    device_number = KippyDeviceUpdateFrequencyNumber(coordinator)
+    with pytest.raises(NotImplementedError):
+        device_number.set_native_value(1)


### PR DESCRIPTION
### ✨ New & Improved

- Device data now refreshes every 15 minutes by default and can be tuned from either the integration’s options flow or the new “Kippy devices update frequency” number entity, giving you full control over how often Home Assistant polls your trackers.
- When new pets appear on the linked Kippy account, the integration detects them and automatically reloads to create entities without any manual intervention.
- All number entities now use box-mode integer inputs for precise adjustments, covering device update frequency, per-pet refresh timers, and activity delays.

### 🛠️ Fixes & Reliability

- Live-tracking state handling now copes with both numeric and text operating-status responses so switches stay in sync with the tracker.
- Unloading the integration now cancels any pending reload tasks and shuts down every coordinator cleanly, preventing lingering background work during reloads or shutdown.
- Persisting per-pet map refresh settings now works with both synchronous and asynchronous Home Assistant APIs, ensuring options save reliably on newer cores.